### PR TITLE
 cg_widescreen and cg_widescreenFov from https://github.com/aufau/SaberMod/tree/widescreen

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -7,7 +7,7 @@
 
 #include "../ui/ui_shared.h"
 
-qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y);
+qboolean CG_WorldCoordToScreenCoord(vec3_t worldCoord, float *x, float *y);
 qboolean CG_CalcMuzzlePoint( int entityNum, vec3_t muzzle );
 
 // used for scoreboard
@@ -104,56 +104,6 @@ void CG_Text_Paint(float x, float y, float scale, vec4_t color, const char *text
 							scale	// const float scale = 1.0f
 							);
 }
-
-/*
-qboolean CG_WorldCoordToScreenCoord(vec3_t worldCoord, int *x, int *y)
-
-  Take any world coord and convert it to a 2D virtual 640x480 screen coord
-*/
-/*
-qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y)
-{
-	int	xcenter, ycenter;
-	vec3_t	local, transformed;
-
-//	xcenter = cg.refdef.width / 2;//gives screen coords adjusted for resolution
-//	ycenter = cg.refdef.height / 2;//gives screen coords adjusted for resolution
-	
-	//NOTE: did it this way because most draw functions expect virtual 640x480 coords
-	//	and adjust them for current resolution
-	xcenter = 640 / 2;//gives screen coords in virtual 640x480, to be adjusted when drawn
-	ycenter = 480 / 2;//gives screen coords in virtual 640x480, to be adjusted when drawn
-
-	VectorSubtract (worldCoord, cg.refdef.vieworg, local);
-
-	transformed[0] = DotProduct(local,vright);
-	transformed[1] = DotProduct(local,vup);
-	transformed[2] = DotProduct(local,vfwd);		
-
-	// Make sure Z is not negative.
-	if(transformed[2] < 0.01)
-	{
-		return qfalse;
-	}
-	// Simple convert to screen coords.
-	float xzi = xcenter / transformed[2] * (90.0/cg.refdef.fov_x);
-	float yzi = ycenter / transformed[2] * (90.0/cg.refdef.fov_y);
-
-	*x = xcenter + xzi * transformed[0];
-	*y = ycenter - yzi * transformed[1];
-
-	return qtrue;
-}
-
-qboolean CG_WorldCoordToScreenCoord( vec3_t worldCoord, int *x, int *y )
-{
-	float	xF, yF;
-	qboolean retVal = CG_WorldCoordToScreenCoordFloat( worldCoord, &xF, &yF );
-	*x = (int)xF;
-	*y = (int)yF;
-	return retVal;
-}
-*/
 
 /*
 ================
@@ -536,7 +486,7 @@ void CG_DrawFlagModel( float x, float y, float w, float h, int team, qboolean fo
 CG_DrawHUDLeftFrame1
 ================
 */
-void CG_DrawHUDLeftFrame1(int x,int y)
+void CG_DrawHUDLeftFrame1(float x, float y)
 {
 	// Inner gray wire frame
 	trap_R_SetColor( hudTintColor );
@@ -548,7 +498,7 @@ void CG_DrawHUDLeftFrame1(int x,int y)
 CG_DrawHUDLeftFrame2
 ================
 */
-void CG_DrawHUDLeftFrame2(int x,int y)
+void CG_DrawHUDLeftFrame2(float x, float y)
 {
 	// Inner gray wire frame
 	trap_R_SetColor( hudTintColor );
@@ -560,7 +510,7 @@ void CG_DrawHUDLeftFrame2(int x,int y)
 DrawHealthArmor
 ================
 */
-void DrawHealthArmor(int x,int y)
+void DrawHealthArmor(float x, float y)
 {
 	vec4_t calcColor;
 	float	armorPercent,hold,healthPercent;
@@ -716,7 +666,7 @@ void DrawHealthArmor(int x,int y)
 CG_DrawHealth
 ================
 */
-void CG_DrawHealth(int x,int y)
+void CG_DrawHealth(float x, float y)
 {
 	vec4_t calcColor;
 	float	healthPercent;
@@ -758,7 +708,7 @@ void CG_DrawHealth(int x,int y)
 CG_DrawArmor
 ================
 */
-void CG_DrawArmor(int x,int y)
+void CG_DrawArmor(float x, float y)
 {
 	vec4_t			calcColor;
 	float			armorPercent,hold;
@@ -836,12 +786,12 @@ void CG_DrawArmor(int x,int y)
 	if (cg.HUDArmorFlag)
 	{
 		trap_R_SetColor( colorTable[CT_HUD_GREEN] );					
-		CG_DrawPic(   x, y, 80, 80, cgs.media.HUDArmorTic );		
+		CG_DrawPic( x, y, 80, 80, cgs.media.HUDArmorTic );		
 	}
 
 	trap_R_SetColor( colorTable[CT_HUD_GREEN] );	
 	CG_DrawNumField (x + 18 + 14, y + 40 + 14, 3, ps->stats[STAT_ARMOR], 6, 12, 
-		NUM_FONT_SMALL,qfalse);
+		NUM_FONT_SMALL, qfalse);
 
 }
 
@@ -2707,7 +2657,7 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 
 	if ( worldPoint && VectorLength( worldPoint ) )
 	{
-		if ( !CG_WorldCoordToScreenCoordFloat( worldPoint, &x, &y ) )
+		if ( !CG_WorldCoordToScreenCoord( worldPoint, &x, &y ) )
 		{//off screen, don't draw it
 			return;
 		}
@@ -2726,7 +2676,7 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 
 }
 
-qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y)
+qboolean CG_WorldCoordToScreenCoord(vec3_t worldCoord, float *x, float *y)
 {
 	float	xcenter, ycenter;
 	vec3_t	local, transformed;
@@ -2767,20 +2717,6 @@ qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y)
 	return qtrue;
 }
 
-qboolean CG_WorldCoordToScreenCoord( vec3_t worldCoord, int *x, int *y )
-{
-	float	xF, yF;
-
-	if (CG_WorldCoordToScreenCoordFloat( worldCoord, &xF, &yF )) {
-		*x = (int)xF;
-		*y = (int)yF;
-
-		return qtrue;
-	}
-
-	return qfalse;
-}
-
 /*
 ====================
 CG_SaberClashFlare
@@ -2792,7 +2728,7 @@ void CG_SaberClashFlare( void )
 {
 	int				t, maxTime = 150;
 	vec3_t dif;
-	int x,y;
+	float x,y;
 	float v, len;
 	trace_t tr;
 
@@ -2945,7 +2881,7 @@ static void CG_DrawActivePowers(void)
 static void CG_DrawRocketLocking( int lockEntNum, int lockTime )
 //--------------------------------------------------------------
 {
-	int		cx, cy;
+	float	cx, cy;
 	vec3_t	org;
 	static	int oldDif = 0;
 	centity_t *cent = &cg_entities[lockEntNum];

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1211,7 +1211,10 @@ void CG_DrawForceSelect( void )
 	pad = 12;
 
 	// Max number of icons on the side
-	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	if (cg_widescreen.integer)
+		sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	else
+		sideMax = 3;
  
 
 	// Calculate how many icons will appear to either side of the center one
@@ -1371,7 +1374,10 @@ void CG_DrawInvenSelect( void )
 	pad = 16;
 
 	// Max number of icons on the side
-	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	if (cg_widescreen.integer)
+		sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	else
+		sideMax = 3;
 
 	// Calculate how many icons will appear to either side of the center one
 	holdCount = count - 1;	// -1 for the center icon

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -194,6 +194,8 @@ static void CG_DrawZoomMask( void )
 		// Using a magic number to convert the zoom level to scale amount
 		level *= 162.0f;
 
+		CG_WideScreenMode(qfalse);
+
 		// draw blue tinted distortion mask, trying to make it as small as is necessary to fill in the viewable area
 		trap_R_SetColor( colorTable[CT_WHITE] );
 		CG_DrawPic( 34, 48, 570, 362, cgs.media.binocularStatic );
@@ -270,6 +272,8 @@ static void CG_DrawZoomMask( void )
 		{
 			flip = !flip;
 		}
+
+		CG_WideScreenMode(qtrue);
 	}
 	else if ( cg.predictedPlayerState.zoomMode)
 	{

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -273,6 +273,8 @@ static void CG_DrawZoomMask( void )
 	}
 	else if ( cg.predictedPlayerState.zoomMode)
 	{
+		float xOffset = 0.5f * (cgs.screenWidth - 640);
+
 		// disruptor zoom mode
 		level = (float)(50.0f - zoomFov) / 50.0f;//(float)(80.0f - zoomFov) / 80.0f;
 
@@ -290,8 +292,11 @@ static void CG_DrawZoomMask( void )
 		level *= 103.0f;
 
 		// Draw target mask
+		CG_FillRect(0, 0, xOffset, 480, colorTable[CT_BLACK]);
+		CG_FillRect(xOffset + 640, 0, xOffset, 480, colorTable[CT_BLACK]);
+
 		trap_R_SetColor( colorTable[CT_WHITE] );
-		CG_DrawPic( 0, 0, 640, 480, cgs.media.disruptorMask );
+		CG_DrawPic(xOffset, 0, 640, 480, cgs.media.disruptorMask);
 
 		// apparently 99.0f is the full zoom level
 		if ( level >= 99 )
@@ -306,7 +311,7 @@ static void CG_DrawZoomMask( void )
 		}
 
 		// Draw rotating insert
-		CG_DrawRotatePic2( 320, 240, 640, 480, -level, cgs.media.disruptorInsert );
+		CG_DrawRotatePic2(0.5f * cgs.screenWidth, 240, 640, 480, -level, cgs.media.disruptorInsert);
 
 		// Increase the light levels under the center of the target
 //		CG_DrawPic( 198, 118, 246, 246, cgs.media.disruptorLight );
@@ -370,7 +375,7 @@ static void CG_DrawZoomMask( void )
 			cx = 320 + sin( (fi+90.0f)/57.296f ) * 190;
 			cy = 240 + cos( (fi+90.0f)/57.296f ) * 190;
 
-			CG_DrawRotatePic2( cx, cy, 12, 24, 90 - fi, cgs.media.disruptorInsertTick );
+			CG_DrawRotatePic2(xOffset + cx, cy, 12, 24, 90 - fi, cgs.media.disruptorInsertTick);
 		}
 
 		if ( cg.predictedPlayerState.weaponstate == WEAPON_CHARGING_ALT )
@@ -385,7 +390,7 @@ static void CG_DrawZoomMask( void )
 				max = 1.0f;
 			}
 
-			trap_R_DrawStretchPic(257, 435, 134*max, 34, 0, 0, max, 1, cgs.media.disruptorChargeShader);
+			trap_R_DrawStretchPic(xOffset + 257, 435, 134*max, 34, 0, 0, max, 1, cgs.media.disruptorChargeShader);
 		}
 //		trap_R_SetColor( colorTable[CT_WHITE] );
 //		CG_DrawPic( 0, 0, 640, 480, cgs.media.disruptorMask );
@@ -403,6 +408,7 @@ CG_Draw3DModel
 void CG_Draw3DModel( float x, float y, float w, float h, qhandle_t model, qhandle_t skin, vec3_t origin, vec3_t angles ) {
 	refdef_t		refdef;
 	refEntity_t		ent;
+	float			xScale, yScale;
 
 	if ( !cg_draw3dIcons.integer || !cg_drawIcons.integer ) {
 		return;
@@ -424,10 +430,12 @@ void CG_Draw3DModel( float x, float y, float w, float h, qhandle_t model, qhandl
 	refdef.fov_x = 30;
 	refdef.fov_y = 30;
 
-	refdef.x = x;
-	refdef.y = y;
-	refdef.width = w;
-	refdef.height = h;
+	xScale = (float) cgs.glconfig.vidWidth / cgs.screenWidth;
+	yScale = (float) cgs.glconfig.vidHeight / SCREEN_HEIGHT;
+	refdef.x = x * xScale;
+	refdef.y = y * yScale;
+	refdef.width = w * xScale;
+	refdef.height = h * yScale;
 
 	refdef.time = cg.time;
 
@@ -838,7 +846,7 @@ void CG_DrawArmor(int x,int y)
 CG_DrawHUDRightFrame1
 ================
 */
-void CG_DrawHUDRightFrame1(int x,int y)
+void CG_DrawHUDRightFrame1(float x, float y)
 {
 	trap_R_SetColor( hudTintColor );
 	// Inner gray wire frame
@@ -850,7 +858,7 @@ void CG_DrawHUDRightFrame1(int x,int y)
 CG_DrawHUDRightFrame2
 ================
 */
-void CG_DrawHUDRightFrame2(int x,int y)
+void CG_DrawHUDRightFrame2(float x, float y)
 {
 	trap_R_SetColor( hudTintColor );
 	CG_DrawPic(   x, y, 80, 80, cgs.media.HUDRightFrame );		// Metal frame
@@ -861,7 +869,7 @@ void CG_DrawHUDRightFrame2(int x,int y)
 CG_DrawAmmo
 ================
 */
-static void CG_DrawAmmo(centity_t	*cent,int x,int y)
+static void CG_DrawAmmo(centity_t *cent, float x, float y)
 {
 	playerState_t	*ps;
 	int			numColor_i;
@@ -993,7 +1001,7 @@ static void CG_DrawAmmo(centity_t	*cent,int x,int y)
 CG_DrawForcePower
 ================
 */
-void CG_DrawForcePower(int x,int y)
+void CG_DrawForcePower(float x, float y)
 {
 	int			i;
 	vec4_t		calcColor;
@@ -1080,10 +1088,10 @@ void CG_DrawHUD(centity_t	*cent)
 			Com_sprintf(ammoString, sizeof(ammoString), "%i", cg.snap->ps.ammo[weaponData[cent->currentState.weapon].ammoIndex]);
 		}
 		
-		UI_DrawProportionalString( SCREEN_WIDTH-(weapX+16+32), y+40, va( "%s", ammoString ),
+		UI_DrawProportionalString( cgs.screenWidth-(weapX+16+32), y+40, va( "%s", ammoString ),
 			UI_SMALLFONT|UI_DROPSHADOW, colorTable[CT_HUD_ORANGE] );
 
-		UI_DrawProportionalString( SCREEN_WIDTH-(x+18+14+32), y+40+14, va( "%i", cg.snap->ps.fd.forcePower),
+		UI_DrawProportionalString( cgs.screenWidth-(x+18+14+32), y+40+14, va( "%i", cg.snap->ps.fd.forcePower),
 			UI_SMALLFONT|UI_DROPSHADOW, colorTable[CT_ICON_BLUE] );
 
 		return;
@@ -1157,7 +1165,7 @@ void CG_DrawHUD(centity_t	*cent)
 	{	// Don't draw a bias.
 		scoreStr = va("Score: %i", cg.snap->ps.persistant[PERS_SCORE]);
 	}
-	UI_DrawScaledProportionalString(SCREEN_WIDTH-101, SCREEN_HEIGHT-23, scoreStr, UI_RIGHT|UI_DROPSHADOW, colorTable[CT_WHITE], 0.7);
+	UI_DrawScaledProportionalString(cgs.screenWidth-101, SCREEN_HEIGHT-23, scoreStr, UI_RIGHT|UI_DROPSHADOW, colorTable[CT_WHITE], 0.7);
 
 	menuHUD = Menus_FindByName("righthud");
 	if (menuHUD)
@@ -1170,10 +1178,10 @@ void CG_DrawHUD(centity_t	*cent)
 	}
 	else
 	{ //Apparently we failed to get proper coordinates from the menu, so resort to manually inputting them.
-		CG_DrawHUDRightFrame1(SCREEN_WIDTH-80,SCREEN_HEIGHT-80);
-		CG_DrawForcePower(SCREEN_WIDTH-80,SCREEN_HEIGHT-80);
-		CG_DrawAmmo(cent,SCREEN_WIDTH-80,SCREEN_HEIGHT-80);
-		CG_DrawHUDRightFrame2(SCREEN_WIDTH-80,SCREEN_HEIGHT-80);
+		CG_DrawHUDRightFrame1(cgs.screenWidth-80,SCREEN_HEIGHT-80);
+		CG_DrawForcePower(cgs.screenWidth-80,SCREEN_HEIGHT-80);
+		CG_DrawAmmo(cent, cgs.screenWidth-80,SCREEN_HEIGHT-80);
+		CG_DrawHUDRightFrame2(cgs.screenWidth-80,SCREEN_HEIGHT-80);
 	}
 }
 
@@ -1206,8 +1214,8 @@ void CG_DrawForceSelect( void )
 {
 	int		i;
 	int		count;
-	int		smallIconSize,bigIconSize;
-	int		holdX,x,y,pad;
+	float	smallIconSize,bigIconSize;
+	float	holdX,x,y,pad;
 	int		sideLeftIconCnt,sideRightIconCnt;
 	int		sideMax,holdCount,iconCnt;
 
@@ -1244,7 +1252,13 @@ void CG_DrawForceSelect( void )
 		return;
 	}
 
-	sideMax = 3;	// Max number of icons on the side
+	smallIconSize = 30;
+	bigIconSize = 60;
+	pad = 12;
+
+	// Max number of icons on the side
+	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+ 
 
 	// Calculate how many icons will appear to either side of the center one
 	holdCount = count - 1;	// -1 for the center icon
@@ -1264,11 +1278,7 @@ void CG_DrawForceSelect( void )
 		sideRightIconCnt = holdCount - sideLeftIconCnt;
 	}
 
-	smallIconSize = 30;
-	bigIconSize = 60;
-	pad = 12;
-
-	x = 320;
+	x = 0.5 * cgs.screenWidth;
 	y = 425;
 
 	i = BG_ProperForceIndex(cg.forceSelect) - 1;
@@ -1341,7 +1351,7 @@ void CG_DrawForceSelect( void )
 
 	if ( showPowersName[cg.forceSelect] ) 
 	{
-		UI_DrawProportionalString(320, y + 30, CG_GetStripEdString("INGAME", showPowersName[cg.forceSelect]), UI_CENTER | UI_SMALLFONT, colorTable[CT_ICON_BLUE]);
+		UI_DrawProportionalString(0.5f * cgs.screenWidth, y + 30, CG_GetStripEdString("INGAME", showPowersName[cg.forceSelect]), UI_CENTER | UI_SMALLFONT, colorTable[CT_ICON_BLUE]);
 	}
 }
 
@@ -1354,10 +1364,10 @@ void CG_DrawInvenSelect( void )
 {
 	int				i;
 	int				sideMax,holdCount,iconCnt;
-	int				smallIconSize,bigIconSize;
+	float			smallIconSize,bigIconSize;
 	int				sideLeftIconCnt,sideRightIconCnt;
 	int				count;
-	int				holdX,x,y,y2,pad;
+	float			holdX,x,y,y2,pad;
 	// int				height;
 	// float			addX;
 
@@ -1398,11 +1408,16 @@ void CG_DrawInvenSelect( void )
 	if (!count)
 	{
 		y2 = 0; //err?
-		UI_DrawProportionalString(320, y2 + 22, "EMPTY INVENTORY", UI_CENTER | UI_SMALLFONT, colorTable[CT_ICON_BLUE]);
+		UI_DrawProportionalString(0.5f * cgs.screenWidth, y2 + 22, "EMPTY INVENTORY", UI_CENTER | UI_SMALLFONT, colorTable[CT_ICON_BLUE]);
 		return;
 	}
 
-	sideMax = 3;	// Max number of icons on the side
+	smallIconSize = 40;
+	bigIconSize = 80;
+	pad = 16;
+
+	// Max number of icons on the side
+	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
 
 	// Calculate how many icons will appear to either side of the center one
 	holdCount = count - 1;	// -1 for the center icon
@@ -1428,11 +1443,7 @@ void CG_DrawInvenSelect( void )
 		i = HI_NUM_HOLDABLE-1;
 	}
 
-	smallIconSize = 40;
-	bigIconSize = 80;
-	pad = 16;
-
-	x = 320;
+	x = 0.5 * cgs.screenWidth;
 	y = 410;
 
 	// Left side ICONS
@@ -1489,11 +1500,11 @@ void CG_DrawInvenSelect( void )
 			
 			if ( trap_SP_GetStringTextString( va("INGAME_%s",bg_itemlist[itemNdex].classname), text, sizeof( text )))
 			{
-				UI_DrawProportionalString(320, y+45, text, UI_CENTER | UI_SMALLFONT, textColor);
+				UI_DrawProportionalString(0.5f * cgs.screenWidth, y+45, text, UI_CENTER | UI_SMALLFONT, textColor);
 			}
 			else
 			{
-				UI_DrawProportionalString(320, y+45, bg_itemlist[itemNdex].classname, UI_CENTER | UI_SMALLFONT, textColor);
+				UI_DrawProportionalString(0.5f * cgs.screenWidth, y+45, bg_itemlist[itemNdex].classname, UI_CENTER | UI_SMALLFONT, textColor);
 			}
 		}
 	}
@@ -1635,7 +1646,7 @@ static float CG_DrawMiniScoreboard ( float y )
 		Q_strcat ( temp, MAX_QPATH, " Blue: " );
 		Q_strcat ( temp, MAX_QPATH, cgs.scores2==SCORE_NOT_PRESENT?"-":(va("%i",cgs.scores2)) );
 
-		CG_Text_Paint( 630 - CG_Text_Width ( temp, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, temp, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM );
+		CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( temp, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, temp, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM );
 		y += 15;
 	}
 	else
@@ -1647,7 +1658,7 @@ static float CG_DrawMiniScoreboard ( float y )
 		Q_strcat ( temp, MAX_QPATH, " 2nd: " );
 		Q_strcat ( temp, MAX_QPATH, cgs.scores2==SCORE_NOT_PRESENT?"-":(va("%i",cgs.scores2)) );
 		
-		CG_Text_Paint( 630 - CG_Text_Width ( temp, 0.7f, FONT_SMALL ), y, 0.7f, colorWhite, temp, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM );
+		CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( temp, 0.7f, FONT_SMALL ), y, 0.7f, colorWhite, temp, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM );
 		y += 15;
 		*/
 		//rww - no longer doing this. Since the attacker now shows who is first, we print the score there.
@@ -1695,16 +1706,16 @@ static float CG_DrawEnemyInfo ( float y )
 			size = ICON_SIZE * 1.25;
 			y += 5;
 
-			CG_DrawPic( 640 - size - 12, y, size, size, cgs.media.weaponIcons[WP_SABER] );
+			CG_DrawPic( cgs.screenWidth - size - 12, y, size, size, cgs.media.weaponIcons[WP_SABER] );
 
 			y += size;
 
 			/*
-			CG_Text_Paint( 630 - CG_Text_Width ( ci->name, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, ci->name, 0, 0, 0, FONT_MEDIUM );
+			CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( ci->name, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, ci->name, 0, 0, 0, FONT_MEDIUM );
 			y += 15;
 			*/
 
-			CG_Text_Paint( 630 - CG_Text_Width ( title, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, title, 0, 0, 0, FONT_MEDIUM );
+			CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( title, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, title, 0, 0, 0, FONT_MEDIUM );
 
 			return y + BIGCHAR_HEIGHT + 2;
 		}
@@ -1783,22 +1794,22 @@ static float CG_DrawEnemyInfo ( float y )
 
 	if ( ci->modelIcon )
 	{
-		CG_DrawPic( 640 - size - 5, y, size, size, ci->modelIcon );
+		CG_DrawPic( cgs.screenWidth - size - 5, y, size, size, ci->modelIcon );
 	}
 
 	y += size;
 
-	CG_Text_Paint( 630 - CG_Text_Width ( ci->name, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, ci->name, 0, 0, 0, FONT_MEDIUM );
+	CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( ci->name, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, ci->name, 0, 0, 0, FONT_MEDIUM );
 
 	y += 15;
-	CG_Text_Paint( 630 - CG_Text_Width ( title, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, title, 0, 0, 0, FONT_MEDIUM );
+	CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( title, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, title, 0, 0, 0, FONT_MEDIUM );
 
 	if ( cgs.gametype == GT_TOURNAMENT && cgs.clientinfo[cg.snap->ps.clientNum].team != TEAM_SPECTATOR)
 	{//also print their score
 		char text[1024];
 		y += 15;
 		Com_sprintf(text, sizeof(text), "%i/%i", cgs.clientinfo[clientNum].score, cgs.fraglimit );
-		CG_Text_Paint( 630 - CG_Text_Width ( text, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, text, 0, 0, 0, FONT_MEDIUM );
+		CG_Text_Paint( cgs.screenWidth - 10 - CG_Text_Width ( text, 0.7f, FONT_MEDIUM ), y, 0.7f, colorWhite, text, 0, 0, 0, FONT_MEDIUM );
 	}
 
 	return y + BIGCHAR_HEIGHT + 2;
@@ -1817,7 +1828,7 @@ static float CG_DrawSnapshot( float y ) {
 		cg.latestSnapshotNum, cgs.serverCommandSequence );
 	w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
 
-	CG_DrawBigString( 635 - w, y + 2, s, 1.0F);
+	CG_DrawBigString(cgs.screenWidth - 5 - w, y + 2, s, 1.0f);
 
 	return y + BIGCHAR_HEIGHT + 4;
 }
@@ -1860,7 +1871,7 @@ static float CG_DrawFPS( float y ) {
 		s = va( "%ifps", fps );
 		w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
 
-		CG_DrawBigString( 635 - w, y + 2, s, 1.0F);
+		CG_DrawBigString(cgs.screenWidth - 5 - w, y + 2, s, 1.0f);
 	}
 
 	return y + BIGCHAR_HEIGHT + 4;
@@ -1888,7 +1899,7 @@ static float CG_DrawTimer( float y ) {
 	s = va( "%i:%i%i", mins, tens, seconds );
 	w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
 
-	CG_DrawBigString( 635 - w, y + 2, s, 1.0F);
+	CG_DrawBigString(cgs.screenWidth - 5 - w, y + 2, s, 1.0f);
 
 	return y + BIGCHAR_HEIGHT + 4;
 }
@@ -1901,7 +1912,8 @@ CG_DrawTeamOverlay
 */
 
 static float CG_DrawTeamOverlay( float y, qboolean right, qboolean upper ) {
-	int x, w, h, xx;
+	float x, w, xx;
+	int h;
 	int i, j, len;
 	const char *p;
 	vec4_t		hcolor;
@@ -1958,7 +1970,7 @@ static float CG_DrawTeamOverlay( float y, qboolean right, qboolean upper ) {
 	w = (pwidth + lwidth + 4 + 7) * TINYCHAR_WIDTH;
 
 	if ( right )
-		x = 640 - w;
+		x = cgs.screenWidth - w;
 	else
 		x = 0;
 
@@ -2072,6 +2084,7 @@ static void CG_DrawPowerupIcons(int y)
 {
 	int j;
 	int ico_size = 64;
+	float xAlign = cgs.screenWidth - ico_size * 1.1f;
 	//int y = ico_size/2;
 	gitem_t	*item;
 
@@ -2109,13 +2122,13 @@ static void CG_DrawPowerupIcons(int y)
 					icoShader = trap_R_RegisterShader( item->icon );
 				}
 
-				CG_DrawPic( (640-(ico_size*1.1)), y, ico_size, ico_size, icoShader );
+				CG_DrawPic( xAlign, y, ico_size, ico_size, icoShader );
 	
 				y += ico_size;
 
 				if (j != PW_REDFLAG && j != PW_BLUEFLAG && secondsleft < 999)
 				{
-					UI_DrawProportionalString((640-(ico_size*1.1))+(ico_size/2), y-8, va("%i", secondsleft), UI_CENTER | UI_BIGFONT | UI_DROPSHADOW, colorTable[CT_WHITE]);
+					UI_DrawProportionalString(xAlign + (ico_size / 2), y - 8, va("%i", secondsleft), UI_CENTER | UI_BIGFONT | UI_DROPSHADOW, colorTable[CT_WHITE]);
 				}
 
 				y += (ico_size/3);
@@ -2208,10 +2221,10 @@ static void CG_DrawReward( void ) {
 
 	if ( cg.rewardCount[0] >= 10 ) {
 		y = 56;
-		x = 320 - ICON_SIZE/2;
-		CG_DrawPic( x, y, ICON_SIZE-4, ICON_SIZE-4, cg.rewardShader[0] );
+		x = 0.5f * (cgs.screenWidth - ICON_SIZE);
+		CG_DrawPic( x + 2, y, ICON_SIZE-4, ICON_SIZE-4, cg.rewardShader[0] );
 		Com_sprintf(buf, sizeof(buf), "%d", cg.rewardCount[0]);
-		x = ( SCREEN_WIDTH - SMALLCHAR_WIDTH * CG_DrawStrlen( buf ) ) / 2;
+		x = ( cgs.screenWidth - SMALLCHAR_WIDTH * CG_DrawStrlen( buf ) ) * 0.5f;
 		CG_DrawStringExt( x, y+ICON_SIZE, buf, color, qfalse, qtrue,
 								SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, 0 );
 	}
@@ -2220,9 +2233,9 @@ static void CG_DrawReward( void ) {
 		count = cg.rewardCount[0];
 
 		y = 56;
-		x = 320 - count * ICON_SIZE/2;
+		x = 0.5f * (cgs.screenWidth - count * ICON_SIZE);
 		for ( i = 0 ; i < count ; i++ ) {
-			CG_DrawPic( x, y, ICON_SIZE-4, ICON_SIZE-4, cg.rewardShader[0] );
+			CG_DrawPic(x + 2, y, ICON_SIZE - 4, ICON_SIZE - 4, cg.rewardShader[0]);
 			x += ICON_SIZE;
 		}
 	}
@@ -2309,11 +2322,11 @@ static void CG_DrawDisconnect( void ) {
 	{			
 		s = CG_GetStripEdString("INGAMETEXT", "SERVER_CHANGING_MAPS");	// s = "Server Changing Maps";			
 		w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		CG_DrawBigString( 320 - w/2, 100, s, 1.0F);
+		CG_DrawBigString(0.5f * (cgs.screenWidth - w), 100, s, 1.0f);
 
 		s = CG_GetStripEdString("INGAMETEXT", "PLEASE_WAIT");	// s = "Please wait...";
 		w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		CG_DrawBigString( 320 - w/2, 200, s, 1.0F);
+		CG_DrawBigString(0.5f * (cgs.screenWidth - w), 200, s, 1.0f);
 		return;
 	}
 
@@ -2328,14 +2341,14 @@ static void CG_DrawDisconnect( void ) {
 	// also add text in center of screen
 	s = CG_GetStripEdString("INGAMETEXT", "CONNECTION_INTERRUPTED"); // s = "Connection Interrupted"; // bk 010215 - FIXME
 	w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-	CG_DrawBigString( 320 - w/2, 100, s, 1.0F);
+	CG_DrawBigString(0.5f * (cgs.screenWidth - w), 100, s, 1.0f);
 
 	// blink the icon
 	if ( ( cg.time >> 9 ) & 1 ) {
 		return;
 	}
 
-	x = 640 - 48;
+	x = cgs.screenWidth - 48;
 	y = 480 - 48;
 
 	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader("gfx/2d/net.tga" ) );
@@ -2365,11 +2378,12 @@ static void CG_DrawLagometer( void ) {
 	//
 	// draw the graph
 	//
-	x = 640 - 48;
+	x = cgs.screenWidth - 48;
 	y = 480 - 144;
 
 	trap_R_SetColor( NULL );
 	CG_DrawPic( x, y, 48, 48, cgs.media.lagometerShader );
+	x -= 1.0f; //lines the actual graph up with the background
 
 	ax = x;
 	ay = y;
@@ -2498,8 +2512,8 @@ CG_DrawCenterString
 static void CG_DrawCenterString( void ) {
 	char	*start;
 	int		l;
-	int		x, y, w;
-	int h;
+	int		y, w, h;
+	float	x;
 	float	*color;
 	const float scale = 1.0; //0.5
 
@@ -2531,7 +2545,7 @@ static void CG_DrawCenterString( void ) {
 
 		w = CG_Text_Width(linebuffer, scale, FONT_MEDIUM);
 		h = CG_Text_Height(linebuffer, scale, FONT_MEDIUM);
-		x = (SCREEN_WIDTH - w) / 2;
+		x = 0.5f * (cgs.screenWidth - w);
 		CG_Text_Paint(x, y + h, scale, color, linebuffer, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM);
 		y += h + 6;
 
@@ -2693,25 +2707,24 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 		{//off screen, don't draw it
 			return;
 		}
-		x -= 320;
-		y -= 240;
 	}
 	else
 	{
-		x = cg_crosshairX.integer;
-		y = cg_crosshairY.integer;
+		x = 0.5f * (cgs.screenWidth - w) + cg_crosshairX.value;
+		y = 0.5f * (SCREEN_HEIGHT - h) + cg_crosshairY.value;
 	}
 
 	hShader = cgs.media.crosshairShader[ cg_drawCrosshair.integer % NUM_CROSSHAIRS ];
+	
+	CG_DrawPic(x + cg.refdef.x - 0.5f * w, y + cg.refdef.y - 0.5f * w, w, h, hShader);
 
-	trap_R_DrawStretchPic( x + cg.refdef.x + 0.5 * (640 - w), 
-		y + cg.refdef.y + 0.5 * (480 - h), 
-		w, h, 0, 0, 1, 1, hShader );
+	trap_R_SetColor( NULL );
+
 }
 
 qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y)
 {
-	int	xcenter, ycenter;
+	float	xcenter, ycenter;
 	vec3_t	local, transformed;
 	vec3_t	vfwd;
 	vec3_t	vright;
@@ -2724,8 +2737,8 @@ qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y)
 	
 	//NOTE: did it this way because most draw functions expect virtual 640x480 coords
 	//	and adjust them for current resolution
-	xcenter = 640 / 2;//gives screen coords in virtual 640x480, to be adjusted when drawn
-	ycenter = 480 / 2;//gives screen coords in virtual 640x480, to be adjusted when drawn
+	xcenter = 0.5f * cgs.screenWidth;
+	ycenter = 0.5f * SCREEN_HEIGHT;
 
 	AngleVectors (cg.refdefViewAngles, vfwd, vright, vup);
 
@@ -2907,7 +2920,7 @@ static void CG_DrawActivePowers(void)
 		{
 			CG_DrawPic( startx, starty, endx, endy, cgs.media.forcePowerIcons[forcePowerSorted[i]]);
 			startx += (icon_size+2); //+2 for spacing
-			if ((startx+icon_size) >= SCREEN_WIDTH-80)
+			if ((startx+icon_size) >= cgs.screenWidth-80)
 			{
 				startx = icon_size*2+16;
 				starty += (icon_size+2);
@@ -3261,7 +3274,7 @@ static void CG_DrawCrosshairNames( void ) {
 	tcolor[2] = colorTable[baseColor][2];
 	tcolor[3] = color[3]*0.5f;
 
-	UI_DrawProportionalString(320, 170, name, UI_CENTER, tcolor);
+	UI_DrawProportionalString(0.5f * cgs.screenWidth, 170, name, UI_CENTER, tcolor);
 
 	trap_R_SetColor( NULL );
 }
@@ -3286,7 +3299,7 @@ static void CG_DrawSpectator(void)
 		int size = 64;
 
 		Com_sprintf(text, sizeof(text), "%s" S_COLOR_WHITE " %s %s", cgs.clientinfo[cgs.duelist1].name, CG_GetStripEdString("INGAMETEXT", "SPECHUD_VERSUS"), cgs.clientinfo[cgs.duelist2].name);
-		CG_Text_Paint ( 320 - CG_Text_Width ( text, 1.0f, 3 ) / 2, 420, 1.0f, colorWhite, text, 0, 0, 0, 3 );
+		CG_Text_Paint ( 0.5f * cgs.screenWidth - CG_Text_Width ( text, 1.0f, 3 ) / 2, 420, 1.0f, colorWhite, text, 0, 0, 0, 3 );
 
 
 		trap_R_SetColor( colorTable[CT_WHITE] );
@@ -3296,30 +3309,30 @@ static void CG_DrawSpectator(void)
 		}
 		if ( cgs.clientinfo[cgs.duelist2].modelIcon )
 		{
-			CG_DrawPic( SCREEN_WIDTH-size-10, SCREEN_HEIGHT-(size*1.5), size, size, cgs.clientinfo[cgs.duelist2].modelIcon );
+			CG_DrawPic( cgs.screenWidth-size-10, SCREEN_HEIGHT-(size*1.5), size, size, cgs.clientinfo[cgs.duelist2].modelIcon );
 		}
 		Com_sprintf(text, sizeof(text), "%i/%i", cgs.clientinfo[cgs.duelist1].score, cgs.fraglimit );
 		CG_Text_Paint( 42 - CG_Text_Width( text, 1.0f, 2 ) / 2, SCREEN_HEIGHT-(size*1.5) + 64, 1.0f, colorWhite, text, 0, 0, 0, 2 );
 
 		Com_sprintf(text, sizeof(text), "%i/%i", cgs.clientinfo[cgs.duelist2].score, cgs.fraglimit );
-		CG_Text_Paint( SCREEN_WIDTH-size+22 - CG_Text_Width( text, 1.0f, 2 ) / 2, SCREEN_HEIGHT-(size*1.5) + 64, 1.0f, colorWhite, text, 0, 0, 0, 2 );
+		CG_Text_Paint( cgs.screenWidth-size+22 - CG_Text_Width( text, 1.0f, 2 ) / 2, SCREEN_HEIGHT-(size*1.5) + 64, 1.0f, colorWhite, text, 0, 0, 0, 2 );
 	}
 	else
 	{
-		CG_Text_Paint ( 320 - CG_Text_Width ( s, 1.0f, 3 ) / 2, 420, 1.0f, colorWhite, s, 0, 0, 0, 3 );
+		CG_Text_Paint ( 0.5f * cgs.screenWidth - CG_Text_Width ( s, 1.0f, 3 ) / 2, 420, 1.0f, colorWhite, s, 0, 0, 0, 3 );
 	}
 
 	if ( cgs.gametype == GT_TOURNAMENT ) 
 	{
 		s = CG_GetStripEdString("INGAMETEXT", "WAITING_TO_PLAY");	// "waiting to play";
-		CG_Text_Paint ( 320 - CG_Text_Width ( s, 1.0f, 3 ) / 2, 440, 1.0f, colorWhite, s, 0, 0, 0, 3 );
+		CG_Text_Paint ( 0.5f * cgs.screenWidth - CG_Text_Width ( s, 1.0f, 3 ) / 2, 440, 1.0f, colorWhite, s, 0, 0, 0, 3 );
 	}
 	else //if ( cgs.gametype >= GT_TEAM ) 
 	{
 		//s = "press ESC and use the JOIN menu to play";
 		s = CG_GetStripEdString("INGAMETEXT", "SPEC_CHOOSEJOIN");
-		CG_Text_Paint ( 320 - CG_Text_Width ( s, 1.0f, 3 ) / 2, 440, 1.0f, colorWhite, s, 0, 0, 0, 3 );
 	}
+		CG_Text_Paint ( 0.5f * cgs.screenWidth - CG_Text_Width ( s, 1.0f, 3 ) / 2, 440, 1.0f, colorWhite, s, 0, 0, 0, 3 );
 }
 
 /*
@@ -3521,6 +3534,7 @@ CG_DrawFollow
 static qboolean CG_DrawFollow( void ) 
 {
 	const char	*s;
+	float		x;
 
 	if ( !(cg.snap->ps.pm_flags & PMF_FOLLOW) ) 
 	{
@@ -3529,10 +3543,12 @@ static qboolean CG_DrawFollow( void )
 
 //	s = "following";
 	s = CG_GetStripEdString("INGAMETEXT", "FOLLOWING");
-	CG_Text_Paint ( 320 - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) / 2, 60, 1.0f, colorWhite, s, 0, 0, 0, FONT_MEDIUM );
+	x = 0.5f * (cgs.screenWidth - CG_Text_Width(s, 1.0f, FONT_MEDIUM));
+	CG_Text_Paint(x , 60, 1.0f, colorWhite, s, 0, 0, 0, FONT_MEDIUM);
 
 	s = cgs.clientinfo[ cg.snap->ps.clientNum ].name;
-	CG_Text_Paint ( 320 - CG_Text_Width ( s, 2.0f, FONT_MEDIUM ) / 2, 80, 2.0f, colorWhite, s, 0, 0, 0, FONT_MEDIUM );
+	x = 0.5f * (cgs.screenWidth - CG_Text_Width(s, 2.0f, FONT_MEDIUM));
+	CG_Text_Paint(x, 80, 2.0f, colorWhite, s, 0, 0, 0, FONT_MEDIUM);
 
 	return qtrue;
 }
@@ -3549,11 +3565,11 @@ static void CG_DrawTemporaryStats()
 
 	sprintf(s, "Force: %i", cg.snap->ps.fd.forcePower);
 
-	CG_DrawBigString(SCREEN_WIDTH-164, SCREEN_HEIGHT-128, s, 1.0f);
+	CG_DrawBigString(cgs.screenWidth-164, SCREEN_HEIGHT-128, s, 1.0f);
 
 	sprintf(s, "Ammo: %i", cg.snap->ps.ammo[weaponData[cg.snap->ps.weapon].ammoIndex]);
 
-	CG_DrawBigString(SCREEN_WIDTH-164, SCREEN_HEIGHT-112, s, 1.0f);
+	CG_DrawBigString(cgs.screenWidth-164, SCREEN_HEIGHT-112, s, 1.0f);
 
 	sprintf(s, "Health: %i", cg.snap->ps.stats[STAT_HEALTH]);
 
@@ -3594,7 +3610,7 @@ static void CG_DrawAmmoWarning( void ) {
 		s = "LOW AMMO WARNING";
 	}
 	w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-	CG_DrawBigString(320 - w / 2, 64, s, 1.0F);
+	CG_DrawBigString(0.5f * (cgs.screenWidth - w), 64, s, 1.0f);
 #endif
 }
 
@@ -3606,7 +3622,7 @@ CG_DrawWarmup
 =================
 */
 static void CG_DrawWarmup( void ) {
-	int			w;
+	float		w;
 	int			sec;
 	int			i;
 	float scale;
@@ -3623,7 +3639,7 @@ static void CG_DrawWarmup( void ) {
 //		s = "Waiting for players";		
 		s = CG_GetStripEdString("INGAMETEXT", "WAITING_FOR_PLAYERS");
 		w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		CG_DrawBigString(320 - w / 2, 24, s, 1.0F);
+		CG_DrawBigString(0.5f * (cgs.screenWidth - w), 24, s, 1.0F);
 		cg.warmupCount = 0;
 		return;
 	}
@@ -3645,7 +3661,7 @@ static void CG_DrawWarmup( void ) {
 		if ( ci1 && ci2 ) {
 			s = va( "%s" S_COLOR_WHITE " vs %s", ci1->name, ci2->name );
 			w = CG_Text_Width(s, 0.6f, FONT_MEDIUM);
-			CG_Text_Paint(320 - w / 2, 60, 0.6f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE,FONT_MEDIUM);
+			CG_Text_Paint(0.5f * (cgs.screenWidth - w), 60, 0.6f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM);
 		}
 	} else {
 		if ( cgs.gametype == GT_FFA ) {
@@ -3666,7 +3682,7 @@ static void CG_DrawWarmup( void ) {
 			s = "";
 		}
 		w = CG_Text_Width(s, 1.5f, FONT_MEDIUM);
-		CG_Text_Paint(320 - w / 2, 90, 1.5f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE,FONT_MEDIUM);
+		CG_Text_Paint(0.5f * (cgs.screenWidth - w), 90, 1.5f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE,FONT_MEDIUM);
 	}
 
 	sec = ( sec - cg.time ) / 1000;
@@ -3713,7 +3729,7 @@ static void CG_DrawWarmup( void ) {
 	}
 
 	w = CG_Text_Width(s, scale, FONT_MEDIUM);
-	CG_Text_Paint(320 - w / 2, 125, scale, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM);
+	CG_Text_Paint(0.5f * (cgs.screenWidth - w), 125, scale, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_SHADOWEDMORE, FONT_MEDIUM);
 }
 
 //==================================================================================
@@ -3897,7 +3913,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			
 			cgRageFadeTime = 0;
@@ -3952,7 +3968,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson && rageTime)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			else
 			{
@@ -3962,7 +3978,7 @@ static void CG_Draw2D( void ) {
 					hcolor[0] = 0.2;
 					hcolor[1] = 0.2;
 					hcolor[2] = 0.2;
-					CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+					CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 				}
 				cgRageTime = 0;
 			}
@@ -3994,7 +4010,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			
 			cgRageRecFadeTime = 0;
@@ -4028,7 +4044,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson && rageRecTime)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			else
 			{
@@ -4063,7 +4079,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			
 			cgAbsorbFadeTime = 0;
@@ -4097,7 +4113,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson && absorbTime)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			else
 			{
@@ -4132,7 +4148,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			
 			cgProtectFadeTime = 0;
@@ -4166,7 +4182,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson && protectTime)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			else
 			{
@@ -4206,7 +4222,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			
 			cgYsalFadeTime = 0;
@@ -4240,7 +4256,7 @@ static void CG_Draw2D( void ) {
 			
 			if (!cg.renderingThirdPerson && ysalTime)
 			{
-				CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+				CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 			}
 			else
 			{
@@ -4369,7 +4385,7 @@ static void CG_Draw2D( void ) {
 		hcolor[1] = 0;
 		hcolor[2] = 0;
 
-		CG_DrawRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH*SCREEN_HEIGHT, hcolor);
+		CG_FillRect(0, 0, cgs.screenWidth, SCREEN_HEIGHT, hcolor);
 
 		if (!gCGHasFallVector)
 		{

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -2670,8 +2670,8 @@ static void CG_DrawCrosshair( vec3_t worldPoint, int chEntValid ) {
 	}
 	else
 	{
-		x = 0.5f * (cgs.screenWidth - w) + cg_crosshairX.value;
-		y = 0.5f * (SCREEN_HEIGHT - h) + cg_crosshairY.value;
+		x = 0.5f * cgs.screenWidth + cg_crosshairX.value;
+		y = 0.5f * SCREEN_HEIGHT + cg_crosshairY.value;
 	}
 
 	hShader = cgs.media.crosshairShader[ cg_drawCrosshair.integer % NUM_CROSSHAIRS ];

--- a/code/cgame/cg_drawtools.c
+++ b/code/cgame/cg_drawtools.c
@@ -83,13 +83,11 @@ Coords are virtual 640x480
 ================
 */
 void CG_DrawSides(float x, float y, float w, float h, float size) {
-	size *= cgs.screenXScale;
 	trap_R_DrawStretchPic( x, y, size, h, 0, 0, 0, 0, cgs.media.whiteShader );
 	trap_R_DrawStretchPic( x + w - size, y, size, h, 0, 0, 0, 0, cgs.media.whiteShader );
 }
 
 void CG_DrawTopBottom(float x, float y, float w, float h, float size) {
-	size *= cgs.screenYScale;
 	trap_R_DrawStretchPic( x, y, w, size, 0, 0, 0, 0, cgs.media.whiteShader );
 	trap_R_DrawStretchPic( x, y + h - size, w, size, 0, 0, 0, 0, cgs.media.whiteShader );
 }

--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -102,6 +102,7 @@ void CG_DrawInformation( void ) {
 	const char	*s;
 	const char	*info;
 	const char	*sysInfo;
+	const float	x = 0.5f * cgs.screenWidth;
 	int			y;
 	int			value, valueNOFP;
 	qhandle_t	levelshot;
@@ -117,7 +118,7 @@ void CG_DrawInformation( void ) {
 		levelshot = trap_R_RegisterShaderNoMip( "menu/art/unknownmap" );
 	}
 	trap_R_SetColor( NULL );
-	CG_DrawPic( 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, levelshot );
+	CG_DrawPic(0, 0, cgs.screenWidth, SCREEN_HEIGHT, levelshot);
 
 	CG_LoadBar();
 				   
@@ -128,11 +129,11 @@ void CG_DrawInformation( void ) {
 	// screen to write into
 	if ( cg.infoScreenText[0] ) {
 		const char *psLoading = CG_GetStripEdString("MENUS3", "LOADING_MAPNAME");
-		UI_DrawProportionalString( 320, 128-32, va(/*"Loading... %s"*/ psLoading, cg.infoScreenText),
+		UI_DrawProportionalString( x, 128-32, va(/*"Loading... %s"*/ psLoading, cg.infoScreenText),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 	} else {
 		const char *psAwaitingSnapshot = CG_GetStripEdString("MENUS3", "AWAITING_SNAPSHOT");
-		UI_DrawProportionalString( 320, 128-32, /*"Awaiting snapshot..."*/psAwaitingSnapshot,
+		UI_DrawProportionalString( x, 128-32, /*"Awaiting snapshot..."*/psAwaitingSnapshot,
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 	}
 
@@ -146,7 +147,7 @@ void CG_DrawInformation( void ) {
 		// server hostname
 		Q_strncpyz(buf, Info_ValueForKey( info, "sv_hostname" ), 1024);
 		Q_CleanStr(buf, (qboolean)(jk2startversion == VERSION_1_02));
-		UI_DrawProportionalString( 320, y, buf,
+		UI_DrawProportionalString( x, y, buf,
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 
@@ -154,7 +155,7 @@ void CG_DrawInformation( void ) {
 		s = Info_ValueForKey( sysInfo, "sv_pure" );
 		if ( s[0] == '1' ) {
 			const char *psPure = CG_GetStripEdString("INGAMETEXT", "PURE_SERVER");
-			UI_DrawProportionalString( 320, y, psPure,
+			UI_DrawProportionalString( x, y, psPure,
 				UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			y += iPropHeight;
 		}
@@ -162,7 +163,7 @@ void CG_DrawInformation( void ) {
 		// server-specific message of the day
 		s = CG_ConfigString( CS_MOTD );
 		if ( s[0] ) {
-			UI_DrawProportionalString( 320, y, s,
+			UI_DrawProportionalString( x, y, s,
 				UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			y += iPropHeight;
 		}
@@ -173,7 +174,7 @@ void CG_DrawInformation( void ) {
 
 			if (motdString[0])
 			{
-				UI_DrawProportionalString( 320, 425, motdString,
+				UI_DrawProportionalString( x, 425, motdString,
 					UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			}
 		}
@@ -185,7 +186,7 @@ void CG_DrawInformation( void ) {
 	// map-specific message (long map name)
 	s = CG_ConfigString( CS_MESSAGE );
 	if ( s[0] ) {
-		UI_DrawProportionalString( 320, y, s,
+		UI_DrawProportionalString( x, y, s,
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
@@ -193,7 +194,7 @@ void CG_DrawInformation( void ) {
 	// cheats warning
 	s = Info_ValueForKey( sysInfo, "sv_cheats" );
 	if ( s[0] == '1' ) {
-		UI_DrawProportionalString( 320, y, CG_GetStripEdString("INGAMETEXT", "CHEATSAREENABLED"),
+		UI_DrawProportionalString( x, y, CG_GetStripEdString("INGAMETEXT", "CHEATSAREENABLED"),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
@@ -231,13 +232,14 @@ void CG_DrawInformation( void ) {
 		s = "Unknown Gametype";
 		break;
 	}
-	UI_DrawProportionalString( 320, y, s,
+	UI_DrawProportionalString( x, y, s,
 		UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 	y += iPropHeight;
 		
 	value = atoi( Info_ValueForKey( info, "timelimit" ) );
 	if ( value ) {
-		UI_DrawProportionalString( 320, y, va( "%s %i", CG_GetStripEdString("INGAMETEXT", "TIMELIMIT"), value ),
+		UI_DrawProportionalString( x, y,
+			va( "%s %i", CG_GetStripEdString("INGAMETEXT", "TIMELIMIT"), value ),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
@@ -245,7 +247,8 @@ void CG_DrawInformation( void ) {
 	if (cgs.gametype < GT_CTF ) {
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );
 		if ( value ) {
-			UI_DrawProportionalString( 320, y, va( "%s %i", CG_GetStripEdString("INGAMETEXT", "FRAGLIMIT"), value ),
+			UI_DrawProportionalString( x, y,
+				va( "%s %i", CG_GetStripEdString("INGAMETEXT", "FRAGLIMIT"), value ),
 				UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			y += iPropHeight;
 		}
@@ -254,7 +257,8 @@ void CG_DrawInformation( void ) {
 		{
 			value = atoi( Info_ValueForKey( info, "duel_fraglimit" ) );
 			if ( value ) {
-				UI_DrawProportionalString( 320, y, va( "%s %i", CG_GetStripEdString("INGAMETEXT", "WINLIMIT"), value ),
+				UI_DrawProportionalString( x, y,
+					va( "%s %i", CG_GetStripEdString("INGAMETEXT", "WINLIMIT"), value ),
 					UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 				y += iPropHeight;
 			}
@@ -264,7 +268,7 @@ void CG_DrawInformation( void ) {
 	if (cgs.gametype >= GT_CTF) {
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 		if ( value ) {
-			UI_DrawProportionalString( 320, y, va( "%s %i", CG_GetStripEdString("INGAMETEXT", "CAPTURELIMIT"), value ),
+			UI_DrawProportionalString( x, y, va( "%s %i", CG_GetStripEdString("INGAMETEXT", "CAPTURELIMIT"), value ),
 				UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			y += iPropHeight;
 		}
@@ -274,7 +278,7 @@ void CG_DrawInformation( void ) {
 	{
 		value = atoi( Info_ValueForKey( info, "g_forceBasedTeams" ) );
 		if ( value ) {
-			UI_DrawProportionalString( 320, y, CG_GetStripEdString("INGAMETEXT", "FORCEBASEDTEAMS"),
+			UI_DrawProportionalString( x, y, CG_GetStripEdString("INGAMETEXT", "FORCEBASEDTEAMS"),
 				UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 			y += iPropHeight;
 		}
@@ -295,7 +299,7 @@ void CG_DrawInformation( void ) {
 			text = va( "%s %i", fmStr, value );
 		}
 
-		UI_DrawProportionalString( 320, y, text, UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
+		UI_DrawProportionalString( x, y, text, UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
 	else if (!valueNOFP)
@@ -303,7 +307,7 @@ void CG_DrawInformation( void ) {
 		char fmStr[1024];
 		trap_SP_GetStringTextString("INGAMETEXT_MAXFORCERANK",fmStr, sizeof(fmStr));
 
-		UI_DrawProportionalString( 320, y, va( "%s %s", fmStr, (char *)CG_GetStripEdString("INGAMETEXT", forceMasteryLevels[7]) ),
+		UI_DrawProportionalString( x, y, va( "%s %s", fmStr, (char *)CG_GetStripEdString("INGAMETEXT", forceMasteryLevels[7]) ),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
@@ -317,13 +321,13 @@ void CG_DrawInformation( void ) {
 		value = atoi( Info_ValueForKey( info, "g_weaponDisable" ) );
 	}
 	if ( cgs.gametype != GT_JEDIMASTER && value ) {
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "SABERONLYSET") ),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "SABERONLYSET") ),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
 
 	if ( valueNOFP ) {
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "NOFPSET") ),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "NOFPSET") ),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 	}
@@ -333,59 +337,59 @@ void CG_DrawInformation( void ) {
 		y += iPropHeight;
 	switch ( cgs.gametype ) {
 	case GT_FFA:					
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_FFA_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_FFA_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_HOLOCRON:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_HOLO_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_HOLO_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_HOLO_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_HOLO_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_JEDIMASTER:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_JEDI_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_JEDI_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_JEDI_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_JEDI_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_SINGLE_PLAYER:
 		break;
 	case GT_TOURNAMENT:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_DUEL_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_DUEL_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_DUEL_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_DUEL_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_TEAM:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_TEAM_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_TEAM_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_TEAM_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_TEAM_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_SAGA:
 		break;
 	case GT_CTF:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTF_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTF_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTF_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTF_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
 	case GT_CTY:
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTY_1")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTY_1")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
-		UI_DrawProportionalString( 320, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTY_2")),
+		UI_DrawProportionalString( x, y, va( "%s", (char *)CG_GetStripEdString("INGAMETEXT", "RULES_CTY_2")),
 			UI_CENTER|UI_INFOFONT|UI_DROPSHADOW, colorWhite );
 		y += iPropHeight;
 		break;
@@ -404,9 +408,12 @@ void CG_LoadBar(void)
 	const int numticks = 9, tickwidth = 40, tickheight = 8;
 	const int tickpadx = 20, tickpady = 12;
 	const int capwidth = 8;
-	const int barwidth = numticks*tickwidth+tickpadx*2+capwidth*2, barleft = ((640-barwidth)/2);
+	const float barwidth = numticks*tickwidth+tickpadx*2+capwidth*2;
+	const float barleft = 0.5f * (cgs.screenWidth - barwidth);
 	const int barheight = tickheight + tickpady*2, bartop = 480-barheight;
-	const int capleft = barleft+tickpadx, tickleft = capleft+capwidth, ticktop = bartop+tickpady;
+	const float capleft = barleft+tickpadx;
+	const float tickleft = capleft+capwidth;
+	const float ticktop = bartop+tickpady;
 
 	trap_R_SetColor( colorWhite );
 	// Draw background

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1305,7 +1305,10 @@ typedef struct {
 	glconfig_t		glconfig;			// rendering configuration
 	float			screenXScale;		// derived from glconfig
 	float			screenYScale;
-	float			screenXBias;
+	//float			screenXBias;
+	float			screenWidth;		// virtual screen width (originally 640)
+	float			screenXFactor;		// 640 / screenWidth (for calculations)
+	float			screenXFactorInv;	// screenWidth / 640
 
 	int				serverCommandSequence;	// reliable command stream counter
 	int				processedSnapshotNum;// the number of snapshots cgame has requested
@@ -1493,6 +1496,9 @@ extern	vmCvar_t		cg_auraShell;
 extern	vmCvar_t		cg_animBlend;
 
 extern	vmCvar_t		cg_dismember;
+
+extern	vmCvar_t		cg_widescreen;
+extern	vmCvar_t		cg_fovAspectAdjust;
 
 extern	vmCvar_t		cg_thirdPerson;
 extern	vmCvar_t		cg_thirdPersonRange;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1598,6 +1598,7 @@ void CG_NextForcePower_f(void);
 void CG_PrevForcePower_f(void);
 void MV_LoadSettings( const char *info );
 void MV_UpdateCgFlags( void );
+void CG_WideScreenMode(qboolean on);
 
 //
 // cg_view.c

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1307,8 +1307,6 @@ typedef struct {
 	float			screenYScale;
 	//float			screenXBias;
 	float			screenWidth;		// virtual screen width (originally 640)
-	float			screenXFactor;		// 640 / screenWidth (for calculations)
-	float			screenXFactorInv;	// screenWidth / 640
 
 	int				serverCommandSequence;	// reliable command stream counter
 	int				processedSnapshotNum;// the number of snapshots cgame has requested

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -127,6 +127,7 @@ char *HolocronIcons[] = {
 };
 
 int forceModelModificationCount = -1;
+int widescreenModificationCount = -1;
 
 void CG_Init( int serverMessageNum, int serverCommandSequence, int clientNum );
 void CG_Shutdown( void );
@@ -510,6 +511,9 @@ vmCvar_t	cg_animBlend;
 
 vmCvar_t	cg_dismember;
 
+vmCvar_t	cg_widescreen;
+vmCvar_t	cg_fovAspectAdjust;
+
 vmCvar_t	cg_thirdPerson;
 vmCvar_t	cg_thirdPersonRange;
 vmCvar_t	cg_thirdPersonAngle;
@@ -668,6 +672,9 @@ static cvarTable_t cvarTable[] = { // bk001129
 
 	{ &cg_dismember, "cg_dismember", "0", CVAR_ARCHIVE },
 
+	{ &cg_widescreen, "cg_widescreen", "1", CVAR_ARCHIVE },
+	{ &cg_fovAspectAdjust, "cg_fovAspectAdjust", "1", CVAR_ARCHIVE },
+
 	{ &cg_thirdPerson, "cg_thirdPerson", "0", 0 },
 	{ &cg_thirdPersonRange, "cg_thirdPersonRange", "80", CVAR_CHEAT },
 	{ &cg_thirdPersonAngle, "cg_thirdPersonAngle", "0", CVAR_CHEAT },
@@ -767,6 +774,8 @@ void CG_RegisterCvars( void ) {
 
 	forceModelModificationCount = cg_forceModel.modificationCount;
 
+	widescreenModificationCount = cg_widescreen.modificationCount;
+
 	trap_Cvar_Register(NULL, "model", DEFAULT_MODEL, CVAR_USERINFO | CVAR_ARCHIVE );
 	//trap_Cvar_Register(NULL, "headmodel", DEFAULT_MODEL, CVAR_USERINFO | CVAR_ARCHIVE );
 	trap_Cvar_Register(NULL, "team_model", DEFAULT_TEAM_MODEL, CVAR_USERINFO | CVAR_ARCHIVE );
@@ -804,6 +813,24 @@ static void CG_ForceModelChange( void ) {
 }
 
 /*
+===================
+CG_UpdateWidescreen
+===================
+*/
+static void CG_UpdateWidescreen(void) {
+	if (cg_widescreen.integer) {
+		cgs.screenWidth = (float)SCREEN_HEIGHT * cgs.glconfig.vidWidth / cgs.glconfig.vidHeight;
+	} else {
+		cgs.screenWidth = (float)SCREEN_WIDTH;
+	}
+	cgs.screenXFactor = (float)SCREEN_WIDTH / cgs.screenWidth;
+	cgs.screenXFactorInv = cgs.screenWidth / (float)SCREEN_WIDTH;
+	
+	if (cg_widescreen.integer != 2)
+		trap_MVAPI_SetVirtualScreen(cgs.screenWidth, (float)SCREEN_HEIGHT);
+}
+
+/*
 =================
 CG_UpdateCvars
 =================
@@ -836,6 +863,11 @@ void CG_UpdateCvars( void ) {
 	if ( forceModelModificationCount != cg_forceModel.modificationCount ) {
 		forceModelModificationCount = cg_forceModel.modificationCount;
 		CG_ForceModelChange();
+	}
+
+	if (widescreenModificationCount != cg_widescreen.modificationCount) {
+		widescreenModificationCount = cg_widescreen.modificationCount;
+		CG_UpdateWidescreen();
 	}
 }
 
@@ -2629,11 +2661,6 @@ Ghoul2 Insert End
 		ammoTicPos[i].tic		= trap_R_RegisterShaderNoMip( ammoTicPos[i].file );
 	}
 
-
-	CG_RegisterCvars();
-
-	CG_InitConsoleCommands();
-
 	cg.weaponSelect = WP_BRYAR_PISTOL;
 
 	cgs.redflag = cgs.blueflag = -1; // For compatibily, default to unset for
@@ -2644,6 +2671,13 @@ Ghoul2 Insert End
 	trap_GetGlconfig( &cgs.glconfig );
 	cgs.screenXScale = cgs.glconfig.vidWidth / 640.0;
 	cgs.screenYScale = cgs.glconfig.vidHeight / 480.0;
+
+
+	CG_RegisterCvars();
+
+	CG_InitConsoleCommands();
+
+	CG_UpdateWidescreen();
 
 	// get the gamestate from the client system
 	trap_GetGameState( &cgs.gameState );

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -841,8 +841,6 @@ static void CG_UpdateWidescreen(void) {
 	} else {
 		cgs.screenWidth = (float)SCREEN_WIDTH;
 	}
-	cgs.screenXFactor = (float)SCREEN_WIDTH / cgs.screenWidth;
-	cgs.screenXFactorInv = cgs.screenWidth / (float)SCREEN_WIDTH;
 	
 	if (mvapi >= 3 && cg_widescreen.integer != 2)
 		trap_MVAPI_SetVirtualScreen(cgs.screenWidth, (float)SCREEN_HEIGHT);

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -814,11 +814,29 @@ static void CG_ForceModelChange( void ) {
 
 /*
 ===================
+CG_WideScreenMode
+Make 2D drawing functions use widescreen or 640x480 coordinates
+===================
+*/
+void CG_WideScreenMode(qboolean on) {
+	if (mvapi >= 3) {
+		if (on) {
+			trap_MVAPI_SetVirtualScreen(cgs.screenWidth, SCREEN_HEIGHT);
+		}
+		else {
+			trap_MVAPI_SetVirtualScreen(SCREEN_WIDTH, SCREEN_HEIGHT);
+		}
+	}
+}
+
+
+/*
+===================
 CG_UpdateWidescreen
 ===================
 */
 static void CG_UpdateWidescreen(void) {
-	if (cg_widescreen.integer) {
+	if (cg_widescreen.integer && mvapi >= 3) {
 		cgs.screenWidth = (float)SCREEN_HEIGHT * cgs.glconfig.vidWidth / cgs.glconfig.vidHeight;
 	} else {
 		cgs.screenWidth = (float)SCREEN_WIDTH;
@@ -826,7 +844,7 @@ static void CG_UpdateWidescreen(void) {
 	cgs.screenXFactor = (float)SCREEN_WIDTH / cgs.screenWidth;
 	cgs.screenXFactorInv = cgs.screenWidth / (float)SCREEN_WIDTH;
 	
-	if (cg_widescreen.integer != 2)
+	if (mvapi >= 3 && cg_widescreen.integer != 2)
 		trap_MVAPI_SetVirtualScreen(cgs.screenWidth, (float)SCREEN_HEIGHT);
 }
 

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -821,10 +821,10 @@ Make 2D drawing functions use widescreen or 640x480 coordinates
 void CG_WideScreenMode(qboolean on) {
 	if (mvapi >= 3) {
 		if (on) {
-			trap_MVAPI_SetVirtualScreen(cgs.screenWidth, SCREEN_HEIGHT);
+			trap_MVAPI_SetVirtualScreen(cgs.screenWidth, (float)SCREEN_HEIGHT);
 		}
 		else {
-			trap_MVAPI_SetVirtualScreen(SCREEN_WIDTH, SCREEN_HEIGHT);
+			trap_MVAPI_SetVirtualScreen((float)SCREEN_WIDTH, (float)SCREEN_HEIGHT);
 		}
 	}
 }

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -673,7 +673,7 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{ &cg_dismember, "cg_dismember", "0", CVAR_ARCHIVE },
 
 	{ &cg_widescreen, "cg_widescreen", "1", CVAR_ARCHIVE },
-	{ &cg_fovAspectAdjust, "cg_fovAspectAdjust", "1", CVAR_ARCHIVE },
+	{ &cg_fovAspectAdjust, "cg_fovAspectAdjust", "0", CVAR_ARCHIVE },
 
 	{ &cg_thirdPerson, "cg_thirdPerson", "0", 0 },
 	{ &cg_thirdPersonRange, "cg_thirdPersonRange", "80", CVAR_CHEAT },

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -4,7 +4,7 @@
 #include "cg_local.h"
 #include "../ui/ui_shared.h"
 
-#define	SCOREBOARD_X		(0)
+#define	SCOREBOARD_X		(0.5f * cgs.screenWidth - 320.0f)
 
 #define SB_HEADER			86
 #define SB_TOP				(SB_HEADER+32)
@@ -30,8 +30,8 @@
 #define SB_BOTICON_X		(SCOREBOARD_X+32)
 #define SB_HEAD_X			(SCOREBOARD_X+64)
 
-#define SB_SCORELINE_X		100
-#define SB_SCORELINE_WIDTH	(640 - SB_SCORELINE_X * 2)
+#define SB_SCORELINE_X		(SCOREBOARD_X+100)
+#define SB_SCORELINE_WIDTH	(cgs.screenWidth - SB_SCORELINE_X * 2)
 
 #define SB_RATING_WIDTH	    0 // (6 * BIGCHAR_WIDTH)
 #define SB_NAME_X			(SB_SCORELINE_X)
@@ -62,7 +62,7 @@ static void CG_DrawClientScore( int y, score_t *score, float *color, float fade,
 {
 	//vec3_t	headAngles;
 	clientInfo_t	*ci;
-	int iconx;
+	float		iconx;
 	float		scale;
 
 	if ( largeFormat )
@@ -93,17 +93,17 @@ static void CG_DrawClientScore( int y, score_t *score, float *color, float fade,
 		}
 	} else if ( ci->powerups & ( 1 << PW_REDFLAG ) ) {
 		if( largeFormat ) {
-			CG_DrawFlagModel( iconx*cgs.screenXScale, y*cgs.screenYScale, 32*cgs.screenXScale, 32*cgs.screenYScale, TEAM_RED, qfalse );
+			CG_DrawFlagModel( iconx, y, 32, 32, TEAM_RED, qfalse );
 		}
 		else {
-			CG_DrawFlagModel( iconx*cgs.screenXScale, y*cgs.screenYScale, 32*cgs.screenXScale, 32*cgs.screenYScale, TEAM_RED, qfalse );
+			CG_DrawFlagModel( iconx, y, 32, 32, TEAM_RED, qfalse );
 		}
 	} else if ( ci->powerups & ( 1 << PW_BLUEFLAG ) ) {
 		if( largeFormat ) {
-			CG_DrawFlagModel( iconx*cgs.screenXScale, y*cgs.screenYScale, 32*cgs.screenXScale, 32*cgs.screenYScale, TEAM_BLUE, qfalse );
+			CG_DrawFlagModel( iconx, y, 32, 32, TEAM_BLUE, qfalse );
 		}
 		else {
-			CG_DrawFlagModel( iconx*cgs.screenXScale, y*cgs.screenYScale, 32*cgs.screenXScale, 32*cgs.screenYScale, TEAM_BLUE, qfalse );
+			CG_DrawFlagModel( iconx, y, 32, 32, TEAM_BLUE, qfalse );
 		}
 	} else {
 		// draw the wins / losses
@@ -149,7 +149,7 @@ static void CG_DrawClientScore( int y, score_t *score, float *color, float fade,
 		}
 
 		hcolor[3] = fade * 0.7;
-		CG_FillRect( SB_SCORELINE_X - 5, y + 2, 640 - SB_SCORELINE_X * 2 + 10, largeFormat?SB_NORMAL_HEIGHT:SB_INTER_HEIGHT, hcolor );
+		CG_FillRect( SB_SCORELINE_X - 5, y + 2, SB_SCORELINE_WIDTH + 10, largeFormat?SB_NORMAL_HEIGHT:SB_INTER_HEIGHT, hcolor );
 	}
 
 	CG_Text_Paint (SB_NAME_X, y, 0.9f * scale, colorWhite, ci->name,0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
@@ -242,7 +242,8 @@ Draw the normal in-game scoreboard
 =================
 */
 qboolean CG_DrawOldScoreboard( void ) {
-	int		x, y, i, n1, n2;
+	float	x;
+	int		y, i, n1, n2;
 	// int		w;
 	float	fade;
 	float	*fadeColor;
@@ -285,37 +286,37 @@ qboolean CG_DrawOldScoreboard( void ) {
 	{
 		s = va("%s" S_COLOR_WHITE " %s", cgs.clientinfo[cgs.duelWinner].name, CG_GetStripEdString("INGAMETEXT", "DUEL_WINS") );
 		/*w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		x = ( SCREEN_WIDTH - w ) / 2;
+		x = 0.5f * ( cgs.screenWidth - w );
 		y = 40;
 		CG_DrawBigString( x, y, s, fade );
 		*/
-		x = ( SCREEN_WIDTH ) / 2;
+		x = 0.5f * ( cgs.screenWidth - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) );
 		y = 40;
-		CG_Text_Paint ( x - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) / 2, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
+		CG_Text_Paint ( x, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 	}
 	else if (cgs.gametype == GT_TOURNAMENT && cgs.duelist1 != -1 && cgs.duelist2 != -1 &&
 		cg.predictedPlayerState.pm_type == PM_INTERMISSION)
 	{
 		s = va("%s" S_COLOR_WHITE " %s %s", cgs.clientinfo[cgs.duelist1].name, CG_GetStripEdString("INGAMETEXT", "SPECHUD_VERSUS"), cgs.clientinfo[cgs.duelist2].name );
 		/*w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		x = ( SCREEN_WIDTH - w ) / 2;
+		x = 0.5f * ( cgs.screenWidth - w );
 		y = 40;
 		CG_DrawBigString( x, y, s, fade );
 		*/
-		x = ( SCREEN_WIDTH ) / 2;
+		x = 0.5f * ( cgs.screenWidth - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) );
 		y = 40;
-		CG_Text_Paint ( x - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) / 2, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
+		CG_Text_Paint ( x, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 	}
 	else if ( cg.killerName[0] ) {
 		s = va("%s %s", CG_GetStripEdString("INGAMETEXT", "KILLEDBY"), cg.killerName );
 		/*w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-		x = ( SCREEN_WIDTH - w ) / 2;
+		x = 0.5f * ( cgs.screenWidth - w );
 		y = 40;
 		CG_DrawBigString( x, y, s, fade );
 		*/
-		x = ( SCREEN_WIDTH ) / 2;
+		x = 0.5f * (cgs.screenWidth - CG_Text_Width(s, 1.0f, FONT_MEDIUM));
 		y = 40;
-		CG_Text_Paint ( x - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) / 2, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
+		CG_Text_Paint ( x, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 	}
 
 	// current rank
@@ -338,7 +339,7 @@ qboolean CG_DrawOldScoreboard( void ) {
 				sWith,
 				cg.snap->ps.persistant[PERS_SCORE] );
 			// w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;
-			x = ( SCREEN_WIDTH ) / 2;
+			x = 0.5f * cgs.screenWidth;
 			y = 60;
 			// CG_DrawBigString( x, y, s, fade );
 			UI_DrawProportionalString(x, y, s, UI_CENTER|UI_DROPSHADOW, colorTable[CT_WHITE]);
@@ -352,10 +353,10 @@ qboolean CG_DrawOldScoreboard( void ) {
 			s = va("Blue leads %i to %i",cg.teamScores[1], cg.teamScores[0] );
 		}
 
-		x = ( SCREEN_WIDTH ) / 2;
+		x = 0.5f * ( cgs.screenWidth - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) );
 		y = 60;
 		
-		CG_Text_Paint ( x - CG_Text_Width ( s, 1.0f, FONT_MEDIUM ) / 2, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
+		CG_Text_Paint ( x, y, 1.0f, colorWhite, s, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM );
 	}
 
 	// scoreboard
@@ -433,14 +434,14 @@ qboolean CG_DrawOldScoreboard( void ) {
 			team2MaxCl = (maxClients-team1MaxCl); //team2 can display however many is left over after team1's display
 
 			n1 = CG_TeamScoreboard( y, TEAM_RED, fade, team1MaxCl, lineHeight, qtrue );
-			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, 640 - SB_SCORELINE_X * 2 + 10, n1 * lineHeight + bottomBorderSize, 0.33f, TEAM_RED );
+			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, SB_SCORELINE_WIDTH + 10, n1 * lineHeight + bottomBorderSize, 0.33f, TEAM_RED );
 			CG_TeamScoreboard( y, TEAM_RED, fade, team1MaxCl, lineHeight, qfalse );
 			y += (n1 * lineHeight) + BIGCHAR_HEIGHT;
 
 			//maxClients -= n1;
 
 			n2 = CG_TeamScoreboard( y, TEAM_BLUE, fade, team2MaxCl, lineHeight, qtrue );
-			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, 640 - SB_SCORELINE_X * 2 + 10, n2 * lineHeight + bottomBorderSize, 0.33f, TEAM_BLUE );
+			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, SB_SCORELINE_WIDTH + 10, n2 * lineHeight + bottomBorderSize, 0.33f, TEAM_BLUE );
 			CG_TeamScoreboard( y, TEAM_BLUE, fade, team2MaxCl, lineHeight, qfalse );
 			y += (n2 * lineHeight) + BIGCHAR_HEIGHT;
 
@@ -466,14 +467,14 @@ qboolean CG_DrawOldScoreboard( void ) {
 			team2MaxCl = (maxClients-team1MaxCl); //team2 can display however many is left over after team1's display
 
 			n1 = CG_TeamScoreboard( y, TEAM_BLUE, fade, team1MaxCl, lineHeight, qtrue );
-			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, 640 - SB_SCORELINE_X * 2 + 10, n1 * lineHeight + bottomBorderSize, 0.33f, TEAM_BLUE );
+			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, SB_SCORELINE_WIDTH + 10, n1 * lineHeight + bottomBorderSize, 0.33f, TEAM_BLUE );
 			CG_TeamScoreboard( y, TEAM_BLUE, fade, team1MaxCl, lineHeight, qfalse );
 			y += (n1 * lineHeight) + BIGCHAR_HEIGHT;
 
 			//maxClients -= n1;
 
 			n2 = CG_TeamScoreboard( y, TEAM_RED, fade, team2MaxCl, lineHeight, qtrue );
-			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, 640 - SB_SCORELINE_X * 2 + 10, n2 * lineHeight + bottomBorderSize, 0.33f, TEAM_RED );
+			CG_DrawTeamBackground( SB_SCORELINE_X - 5, y - topBorderSize, SB_SCORELINE_WIDTH + 10, n2 * lineHeight + bottomBorderSize, 0.33f, TEAM_RED );
 			CG_TeamScoreboard( y, TEAM_RED, fade, team2MaxCl, lineHeight, qfalse );
 			y += (n2 * lineHeight) + BIGCHAR_HEIGHT;
 

--- a/code/cgame/cg_syscalls.c
+++ b/code/cgame/cg_syscalls.c
@@ -905,5 +905,5 @@ void trap_R_AddRefEntityToScene2( const refEntity_t *re )
 
 void trap_MVAPI_SetVirtualScreen( float w, float h )
 {
-	syscall( CG_MVAPI_SETVIRTUALSCREEN, w, h );
+	syscall( CG_MVAPI_SETVIRTUALSCREEN, PASSFLOAT(w), PASSFLOAT(h) );
 }

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -1017,9 +1017,7 @@ static int CG_CalcFov( void ) {
 		}
 	}
 
-	// don't allow without cg_widescreen so people don't use it to
-	// stretch disruptor zoom mask
-	if (cg_widescreen.integer && cg_fovAspectAdjust.integer &&
+	if (cg_fovAspectAdjust.integer &&
 		cg.refdef.width * 3 > cg.refdef.height * 4)
 	{
 		// 4:3 screen with fov_x must fit INTO widescreen

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -1017,9 +1017,23 @@ static int CG_CalcFov( void ) {
 		}
 	}
 
-	x = cg.refdef.width / tan( fov_x / 360 * M_PI );
-	fov_y = atan2( cg.refdef.height, x );
-	fov_y = fov_y * 360 / M_PI;
+	// don't allow without cg_widescreen so people don't use it to
+	// stretch disruptor zoom mask
+	if (cg_widescreen.integer && cg_fovAspectAdjust.integer &&
+		cg.refdef.width * 3 > cg.refdef.height * 4)
+	{
+		// 4:3 screen with fov_x must fit INTO widescreen
+		float width = cg.refdef.height * (4.0f / 3.0f);
+
+		x = width / tan(DEG2RAD(0.5f * fov_x));
+		fov_x = RAD2DEG(2 * atan2(cg.refdef.width, x));
+		fov_y = RAD2DEG(2 * atan2(cg.refdef.height, x));
+	}
+	else
+	{
+		x = cg.refdef.width / tan(DEG2RAD(0.5f * fov_x));
+		fov_y = RAD2DEG(2 * atan2(cg.refdef.height, x));
+	}
 
 	// warp if underwater
 	contents = CG_PointContents( cg.refdef.vieworg, -1 );

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1097,7 +1097,10 @@ void CG_DrawWeaponSelect( void ) {
 	pad = 12;
 
 	// Max number of icons on the side
-	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	if (cg_widescreen.integer)
+		sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
+	else
+		sideMax = 3;
 
 	// Calculate how many icons will appear to either side of the center one
 	holdCount = count - 1;	// -1 for the center icon

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -855,7 +855,8 @@ WEAPON SELECTION
 void CG_DrawIconBackground(void)
 {
 	int				height,xAdd,x2,y2,t;
-	int				prongLeftX,prongRightX;
+	float			prongLeftX, prongRightX;
+	float			prongWidth;
 	float			inTime = cg.invenSelectTime+WEAPON_SELECT_TIME;
 	float			wpTime = cg.weaponSelectTime+WEAPON_SELECT_TIME;
 	float			fpTime = cg.forceSelectTime+WEAPON_SELECT_TIME;
@@ -877,8 +878,9 @@ void CG_DrawIconBackground(void)
 	x2 = 30;
 	y2 = SCREEN_HEIGHT-70;
 
-	prongLeftX =x2+37; 
-	prongRightX =x2+544; 
+	prongLeftX = x2 + 37; 
+	prongRightX = cgs.screenWidth - x2 - 37 + 1;
+	prongWidth = cgs.screenWidth - 2 * (x2 + 60);
 
 	if (inTime > wpTime)
 	{
@@ -917,8 +919,8 @@ void CG_DrawIconBackground(void)
 			xAdd = (int) 8*cg.iconHUDPercent;
 
 			height = (int) (60.0f*cg.iconHUDPercent);
-			CG_DrawPic( x2+60, y2+30, 460, -height, drawType);	// Top half
-			CG_DrawPic( x2+60, y2+30-2,460, height, drawType);	// Bottom half
+			CG_DrawPic( x2+60, y2+30, prongWidth, -height, drawType);	// Top half
+			CG_DrawPic( x2+60, y2+30-2, prongWidth, height, drawType);	// Bottom half
 
 		}
 		else
@@ -932,8 +934,6 @@ void CG_DrawIconBackground(void)
 
 		return;
 	}
-	prongLeftX =x2+37; 
-	prongRightX =x2+544; 
 
 	if (!cg.iconHUDActive)
 	{
@@ -958,8 +958,8 @@ void CG_DrawIconBackground(void)
 
 	trap_R_SetColor( colorTable[CT_WHITE] );					
 	height = (int) (60.0f*cg.iconHUDPercent);
-	CG_DrawPic( x2+60, y2+30, 460, -height, drawType);	// Top half
-	CG_DrawPic( x2+60, y2+30-2,460, height, drawType);	// Bottom half
+	CG_DrawPic( x2+60, y2+30, prongWidth, -height, drawType);	// Top half
+	CG_DrawPic( x2+60, y2+30-2, prongWidth, height, drawType);	// Bottom half
 
 	// And now for the prongs
 /*	if ((cg.inventorySelectTime+WEAPON_SELECT_TIME)>cg.time)	
@@ -1039,8 +1039,8 @@ void CG_DrawWeaponSelect( void ) {
 	int				i;
 	int				bits;
 	int				count;
-	int				smallIconSize,bigIconSize;
-	int				holdX,x,y,pad;
+	float			smallIconSize,bigIconSize;
+	float			holdX,x,y,pad;
 	int				sideLeftIconCnt,sideRightIconCnt;
 	int				sideMax,holdCount,iconCnt;
 
@@ -1092,7 +1092,12 @@ void CG_DrawWeaponSelect( void ) {
 		return;
 	}
 
-	sideMax = 3;	// Max number of icons on the side
+	smallIconSize = 40;
+	bigIconSize = 80;
+	pad = 12;
+
+	// Max number of icons on the side
+	sideMax = (cgs.screenWidth - 240 - bigIconSize) / (smallIconSize + pad) / 2;
 
 	// Calculate how many icons will appear to either side of the center one
 	holdCount = count - 1;	// -1 for the center icon
@@ -1118,11 +1123,7 @@ void CG_DrawWeaponSelect( void ) {
 		i = 13;
 	}
 
-	smallIconSize = 40;
-	bigIconSize = 80;
-	pad = 12;
-
-	x = 320;
+	x = 0.5f * cgs.screenWidth;
 	y = 410;
 
 	// Background
@@ -1247,11 +1248,11 @@ void CG_DrawWeaponSelect( void ) {
 		
 		if ( trap_SP_GetStringTextString( va("INGAME_%s",cg_weapons[ cg.weaponSelect ].item->classname), text, sizeof( text )))
 		{
-			UI_DrawProportionalString(320, y+45, text, UI_CENTER|UI_SMALLFONT, textColor);
+			UI_DrawProportionalString(0.5f * cgs.screenWidth, y+45, text, UI_CENTER|UI_SMALLFONT, textColor);
 		}
 		else
 		{
-			UI_DrawProportionalString(320, y+45, cg_weapons[ cg.weaponSelect ].item->classname, UI_CENTER|UI_SMALLFONT, textColor);
+			UI_DrawProportionalString(0.5f * cgs.screenWidth, y+45, cg_weapons[ cg.weaponSelect ].item->classname, UI_CENTER|UI_SMALLFONT, textColor);
 		}
 	}
 

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -841,6 +841,10 @@ typedef struct {
 
 	qboolean inGameLoad;
 
+	float		screenWidth;
+	float		screenXFactor;
+	float		screenXFactorInv;
+
 }	uiInfo_t;
 
 extern uiInfo_t uiInfo;

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -6791,7 +6791,7 @@ UI_MouseEvent
 void _UI_MouseEvent( int dx, int dy )
 {
 	// update mouse screen position
-	uiInfo.uiDC.cursorx += dx * uiInfo.uiDC.screenXFactor;
+	uiInfo.uiDC.cursorx += dx * uiInfo.screenXFactor;
 	if (uiInfo.uiDC.cursorx < 0)
 		uiInfo.uiDC.cursorx = 0;
 	else if (uiInfo.uiDC.cursorx > SCREEN_WIDTH)

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -217,7 +217,7 @@ Make 2D drawing functions use widescreen or 640x480 coordinates
 void UI_WideScreenMode(qboolean on) {
 	if (mvapi >= 3) {
 		if (on) {
-			trap_MVAPI_SetVirtualScreen(uiInfo.uiDC.screenWidth, (float)SCREEN_HEIGHT);
+			trap_MVAPI_SetVirtualScreen(uiInfo.screenWidth, (float)SCREEN_HEIGHT);
 		}
 		else {
 			trap_MVAPI_SetVirtualScreen((float)SCREEN_WIDTH, (float)SCREEN_HEIGHT);
@@ -233,16 +233,16 @@ UI_UpdateWidescreen
 extern vmCvar_t ui_widescreen;
 static void UI_UpdateWidescreen(void) {
 	if (ui_widescreen.integer && mvapi >= 3) {
-		uiInfo.uiDC.screenWidth = (float)SCREEN_HEIGHT * uiInfo.uiDC.glconfig.vidWidth / uiInfo.uiDC.glconfig.vidHeight;
+		uiInfo.screenWidth = (float)SCREEN_HEIGHT * uiInfo.uiDC.glconfig.vidWidth / uiInfo.uiDC.glconfig.vidHeight;
 	}
 	else {
-		uiInfo.uiDC.screenWidth = (float)SCREEN_WIDTH;
+		uiInfo.screenWidth = (float)SCREEN_WIDTH;
 	}
-	uiInfo.uiDC.screenXFactor = (float)SCREEN_WIDTH / uiInfo.uiDC.screenWidth;
-	uiInfo.uiDC.screenXFactorInv = uiInfo.uiDC.screenWidth / (float)SCREEN_WIDTH;
+	uiInfo.screenXFactor = (float)SCREEN_WIDTH / uiInfo.screenWidth;
+	uiInfo.screenXFactorInv = uiInfo.screenWidth / (float)SCREEN_WIDTH;
 
 	if (mvapi >= 3 && ui_widescreen.integer != 2)
-		trap_MVAPI_SetVirtualScreen(uiInfo.uiDC.screenWidth, (float)SCREEN_HEIGHT);
+		trap_MVAPI_SetVirtualScreen(uiInfo.screenWidth, (float)SCREEN_HEIGHT);
 }
 
 menuDef_t *Menus_FindByName(const char *p);
@@ -460,7 +460,7 @@ int Text_Width(const char *text, float scale, int iMenuFont)
 	float w;
 
 	UI_WideScreenMode(qtrue);
-	w = trap_R_Font_StrLenPixels(text, iFontIndex, scale) * uiInfo.uiDC.screenXFactor;
+	w = trap_R_Font_StrLenPixels(text, iFontIndex, scale) * uiInfo.screenXFactor;
 	UI_WideScreenMode(qfalse);
 	return w;
 }
@@ -495,7 +495,7 @@ void Text_Paint(float x, float y, float scale, vec4_t color, const char *text, f
 	}
 
 	UI_WideScreenMode(qtrue);
-	x *= uiInfo.uiDC.screenXFactorInv;
+	x *= uiInfo.screenXFactorInv;
 	trap_R_Font_DrawString(	x,						// int ox
 							y,						// int oy
 							text,					// const char *text
@@ -680,7 +680,7 @@ void _UI_Refresh( int realtime )
 	UI_SetColor( NULL );
 	if (Menu_Count() > 0) {
 		UI_WideScreenMode(qtrue);
-		UI_DrawHandlePic(uiInfo.uiDC.cursorx * uiInfo.uiDC.screenXFactorInv, uiInfo.uiDC.cursory, 48, 48, uiInfo.uiDC.Assets.cursor);
+		UI_DrawHandlePic(uiInfo.uiDC.cursorx * uiInfo.screenXFactorInv, uiInfo.uiDC.cursory, 48, 48, uiInfo.uiDC.Assets.cursor);
 		UI_WideScreenMode(qfalse);
 	}
 

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -381,13 +381,11 @@ void AssetCache() {
 }
 
 void _UI_DrawSides(float x, float y, float w, float h, float size) {
-	size *= uiInfo.uiDC.xscale;
 	trap_R_DrawStretchPic( x, y, size, h, 0, 0, 0, 0, uiInfo.uiDC.whiteShader );
 	trap_R_DrawStretchPic( x + w - size, y, size, h, 0, 0, 0, 0, uiInfo.uiDC.whiteShader );
 }
 
 void _UI_DrawTopBottom(float x, float y, float w, float h, float size) {
-	size *= uiInfo.uiDC.yscale;
 	trap_R_DrawStretchPic( x, y, w, size, 0, 0, 0, 0, uiInfo.uiDC.whiteShader );
 	trap_R_DrawStretchPic( x, y + h - size, w, size, 0, 0, 0, 0, uiInfo.uiDC.whiteShader );
 }

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -7436,7 +7436,7 @@ static cvarTable_t		cvarTable[] = {
 	{ &ui_serverStatusTimeOut, "ui_serverStatusTimeOut", "7000", CVAR_ARCHIVE},
 	{ &ui_s_language, "s_language", "english", CVAR_ARCHIVE | CVAR_NORESTART},
 
-	{ &ui_widescreen, "cg_widescreen", "1", 0 },
+	{ &ui_widescreen, "ui_widescreen", "1", CVAR_ARCHIVE | CVAR_LATCH },
 
 	{ &ui_MVSDK, "ui_MVSDK", MVSDK_VERSION, CVAR_ROM | CVAR_USERINFO },
 };

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -411,10 +411,6 @@ typedef struct {
 	qhandle_t cursor;
 	float FPS;
 
-	float		screenWidth;
-	float		screenXFactor;
-	float		screenXFactorInv;
-
 } displayContextDef_t;
 
 const char *String_Alloc(const char *p);

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -90,8 +90,8 @@
 #define	NUM_CROSSHAIRS			10
 
 typedef struct {
-  const char *command;
-  const char *args[MAX_SCRIPT_ARGS];
+	const char *command;
+	const char *args[MAX_SCRIPT_ARGS];
 } scriptDef_t;
 
 
@@ -224,7 +224,7 @@ typedef struct textScrollDef_s
 
 typedef struct itemDef_s {
 	Window		window;						// common positional, border, style, layout info
-	Rectangle	textRect;					// rectangle the text ( if any ) consumes     
+	Rectangle	textRect;					// rectangle the text ( if any ) consumes
 	int			type;						// text, button, radiobutton, checkbox, textfield, listbox, combo
 	int			alignment;					// left center right
 	int			textalignment;				// ( optional ) alignment for text within rect based on text width
@@ -277,7 +277,7 @@ typedef struct {
 
 	vec4_t focusColor;						// focus color for items
 	vec4_t disableColor;					// focus color for items
-	itemDef_t *items[MAX_MENUITEMS];		// items this menu contains   
+	itemDef_t *items[MAX_MENUITEMS];		// items this menu contains
 	int			descX;						// X position of description
 	int			descY;						// X position of description
 	vec4_t		descColor;					// description text color for items
@@ -289,41 +289,41 @@ typedef struct {
 } menuDef_t;
 
 typedef struct {
-  const char *fontStr;
-  const char *cursorStr;
-  const char *gradientStr;
-  qhandle_t	qhSmallFont;
-  qhandle_t	qhMediumFont;
-  qhandle_t	qhBigFont;
-  qhandle_t cursor;
-  qhandle_t gradientBar;
-  qhandle_t scrollBarArrowUp;
-  qhandle_t scrollBarArrowDown;
-  qhandle_t scrollBarArrowLeft;
-  qhandle_t scrollBarArrowRight;
-  qhandle_t scrollBar;
-  qhandle_t scrollBarThumb;
-  qhandle_t buttonMiddle;
-  qhandle_t buttonInside;
-  qhandle_t solidBox;
-  qhandle_t sliderBar;
-  qhandle_t sliderThumb;
-  sfxHandle_t menuEnterSound;
-  sfxHandle_t menuExitSound;
-  sfxHandle_t menuBuzzSound;
-  sfxHandle_t itemFocusSound;
-  float fadeClamp;
-  int fadeCycle;
-  float fadeAmount;
-  float shadowX;
-  float shadowY;
-  vec4_t shadowColor;
-  float shadowFadeClamp;
-  qboolean fontRegistered;
+	const char *fontStr;
+	const char *cursorStr;
+	const char *gradientStr;
+	qhandle_t	qhSmallFont;
+	qhandle_t	qhMediumFont;
+	qhandle_t	qhBigFont;
+	qhandle_t cursor;
+	qhandle_t gradientBar;
+	qhandle_t scrollBarArrowUp;
+	qhandle_t scrollBarArrowDown;
+	qhandle_t scrollBarArrowLeft;
+	qhandle_t scrollBarArrowRight;
+	qhandle_t scrollBar;
+	qhandle_t scrollBarThumb;
+	qhandle_t buttonMiddle;
+	qhandle_t buttonInside;
+	qhandle_t solidBox;
+	qhandle_t sliderBar;
+	qhandle_t sliderThumb;
+	sfxHandle_t menuEnterSound;
+	sfxHandle_t menuExitSound;
+	sfxHandle_t menuBuzzSound;
+	sfxHandle_t itemFocusSound;
+	float fadeClamp;
+	int fadeCycle;
+	float fadeAmount;
+	float shadowX;
+	float shadowY;
+	vec4_t shadowColor;
+	float shadowFadeClamp;
+	qboolean fontRegistered;
 
-  // player settings
+	// player settings
 	qhandle_t fxBasePic;
-  qhandle_t fxPic[7];
+	qhandle_t fxPic[7];
 	qhandle_t	crosshairShader[NUM_CROSSHAIRS];
 
 } cachedAssets_t;
@@ -335,22 +335,22 @@ typedef struct
 } commandDef_t;
 
 typedef struct {
-  qhandle_t (*registerShaderNoMip) (const char *p);
-  void (*setColor) (const vec4_t v);
-  void (*drawHandlePic) (float x, float y, float w, float h, qhandle_t asset);
-  void (*drawStretchPic) (float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader );
-  void (*drawText) (float x, float y, float scale, vec4_t color, const char *text, float adjust, int limit, int style, int iMenuFont);  
-  int (*textWidth) (const char *text, float scale, int iMenuFont);  
-  int (*textHeight) (const char *text, float scale, int iMenuFont);
-  qhandle_t (*registerModel) (const char *p);
-  void (*modelBounds) (qhandle_t model, vec3_t min, vec3_t max);
-  void (*fillRect) ( float x, float y, float w, float h, const vec4_t color);
-  void (*drawRect) ( float x, float y, float w, float h, float size, const vec4_t color);
-  void (*drawSides) (float x, float y, float w, float h, float size);
-  void (*drawTopBottom) (float x, float y, float w, float h, float size);
-  void (*clearScene) ();
-  void (*addRefEntityToScene) (const refEntity_t *re );
-  void (*renderScene) ( const refdef_t *fd );
+	qhandle_t (*registerShaderNoMip) (const char *p);
+	void (*setColor) (const vec4_t v);
+	void (*drawHandlePic) (float x, float y, float w, float h, qhandle_t asset);
+	void (*drawStretchPic) (float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader );
+	void (*drawText) (float x, float y, float scale, vec4_t color, const char *text, float adjust, int limit, int style, int iMenuFont);
+	int (*textWidth) (const char *text, float scale, int iMenuFont);
+	int (*textHeight) (const char *text, float scale, int iMenuFont);
+	qhandle_t (*registerModel) (const char *p);
+	void (*modelBounds) (qhandle_t model, vec3_t min, vec3_t max);
+	void (*fillRect) ( float x, float y, float w, float h, const vec4_t color);
+	void (*drawRect) ( float x, float y, float w, float h, float size, const vec4_t color);
+	void (*drawSides) (float x, float y, float w, float h, float size);
+	void (*drawTopBottom) (float x, float y, float w, float h, float size);
+	void (*clearScene) ();
+	void (*addRefEntityToScene) (const refEntity_t *re );
+	void (*renderScene) ( const refdef_t *fd );
 
 	qhandle_t (*RegisterFont)( const char *fontName );
 	int		(*Font_StrLenPixels) (const char *text, const int iFontIndex, const float scale);
@@ -360,24 +360,24 @@ typedef struct {
 	qboolean (*Language_IsAsian)(void);
 	qboolean (*Language_UsesSpaces)(void);
 	//unsigned int (*AnyLanguage_ReadCharFromString)( const char *psText, int *piAdvanceCount, qboolean *pbIsTrailingPunctuation/* = NULL*/ );
-  void (*ownerDrawItem) (float x, float y, float w, float h, float text_x, float text_y, int ownerDraw, int ownerDrawFlags, int align, float special, float scale, vec4_t color, qhandle_t shader, int textStyle,int iMenuFont);
+	void (*ownerDrawItem) (float x, float y, float w, float h, float text_x, float text_y, int ownerDraw, int ownerDrawFlags, int align, float special, float scale, vec4_t color, qhandle_t shader, int textStyle,int iMenuFont);
 	float (*getValue) (int ownerDraw);
 	qboolean (*ownerDrawVisible) (int flags);
-  void (*runScript)(char **p);
-  qboolean (*deferScript)(char **p);
-  void (*getTeamColor)(vec4_t *color);
-  void (*getCVarString)(const char *cvar, char *buffer, int bufsize);
-  float (*getCVarValue)(const char *cvar);
-  void (*setCVar)(const char *cvar, const char *value);
-  void (*drawTextWithCursor)(float x, float y, float scale, vec4_t color, const char *text, int cursorPos, char cursor, int limit, int style, int iFontIndex);
-  void (*setOverstrikeMode)(qboolean b);
-  qboolean (*getOverstrikeMode)();
-  void (*startLocalSound)( sfxHandle_t sfx, int channelNum );
-  qboolean (*ownerDrawHandleKey)(int ownerDraw, int flags, float *special, int key);
-  int (*feederCount)(float feederID);
-  const char *(*feederItemText)(float feederID, int index, int column, qhandle_t *handle1, qhandle_t *handle2, qhandle_t *handle3);
-  qhandle_t (*feederItemImage)(float feederID, int index);
-  qboolean (*feederSelection)(float feederID, int index);
+	void (*runScript)(char **p);
+	qboolean (*deferScript)(char **p);
+	void (*getTeamColor)(vec4_t *color);
+	void (*getCVarString)(const char *cvar, char *buffer, int bufsize);
+	float (*getCVarValue)(const char *cvar);
+	void (*setCVar)(const char *cvar, const char *value);
+	void (*drawTextWithCursor)(float x, float y, float scale, vec4_t color, const char *text, int cursorPos, char cursor, int limit, int style, int iFontIndex);
+	void (*setOverstrikeMode)(qboolean b);
+	qboolean (*getOverstrikeMode)();
+	void (*startLocalSound)( sfxHandle_t sfx, int channelNum );
+	qboolean (*ownerDrawHandleKey)(int ownerDraw, int flags, float *special, int key);
+	int (*feederCount)(float feederID);
+	const char *(*feederItemText)(float feederID, int index, int column, qhandle_t *handle1, qhandle_t *handle2, qhandle_t *handle3);
+	qhandle_t (*feederItemImage)(float feederID, int index);
+	qboolean (*feederSelection)(float feederID, int index);
 	void (*keynumToStringBuf)( int keynum, char *buf, int buflen );
 	void (*getBindingBuf)( int keynum, char *buf, int buflen );
 	void (*setBinding)( int keynum, const char *binding );
@@ -394,22 +394,26 @@ typedef struct {
 	void (*drawCinematic)(int handle, float x, float y, float w, float h);
 	void (*runCinematicFrame)(int handle);
 
-  float			yscale;
-  float			xscale;
+	float			yscale;
+	float			xscale;
   float			bias;
   int				realTime;
   int				frameTime;
-	int				cursorx;
-	int				cursory;
+	float			cursorx;
+	float			cursory;
 	qboolean	debug;
 
   cachedAssets_t Assets;
 
 	glconfig_t glconfig;
 	qhandle_t	whiteShader;
-  qhandle_t gradientImage;
-  qhandle_t cursor;
+	qhandle_t gradientImage;
+	qhandle_t cursor;
 	float FPS;
+
+	float		screenWidth;
+	float		screenXFactor;
+	float		screenXFactorInv;
 
 } displayContextDef_t;
 

--- a/code/ui/ui_syscalls.c
+++ b/code/ui/ui_syscalls.c
@@ -623,5 +623,5 @@ void trap_R_AddRefEntityToScene2( const refEntity_t *re )
 
 void trap_MVAPI_SetVirtualScreen( float w, float h )
 {
-	syscall( UI_MVAPI_SETVIRTUALSCREEN, w, h );
+	syscall( UI_MVAPI_SETVIRTUALSCREEN, PASSFLOAT(w), PASSFLOAT(h) );
 }


### PR DESCRIPTION
cg_widescreenFov renamed to cg_fovAspectAdjust, to match OpenJK's cvar name

As discussed in https://github.com/mvdevs/jk2mv/issues/49/
Uses the new trap_MVAPI_SetVirtualScreen syscall to correct the 2D graphic stretching in cgame seen  on the HUD when using a widescreen resolution.  Also adds fau's cg_widescreenFov code which corrects the cutoff on the field of view in 16:9/16:10 resolutions (which is exactly what cg_fovAspectAdjust does in OpenJK), both default to 1.

Screenshots taken in 1920x1080 (16:9).

Before (1st person with default cg_fov 80)
![shot0003](https://user-images.githubusercontent.com/3673929/45390393-5ba87780-b5dc-11e8-85d7-223924a4d983.jpg)
After (1st person with default cg_fov 80)
![shot0004](https://user-images.githubusercontent.com/3673929/45390399-5f3bfe80-b5dc-11e8-99a9-57c150bd008e.jpg)



Disruptor scope with cg_widescreen 0
![scopebefore](https://user-images.githubusercontent.com/3673929/45390080-264f5a00-b5db-11e8-8bfe-23c7bd5ac4da.jpg)
Disruptor scope with cg_widescreen 1
![scopeafter](https://user-images.githubusercontent.com/3673929/45390091-2e0efe80-b5db-11e8-94ed-4c8e83415f63.jpg)



3rd person cg_fov 97 with cg_fovAspectAdjust 0 
![fovadjustbefore](https://user-images.githubusercontent.com/3673929/45390059-18013e00-b5db-11e8-955e-0149cb42f294.jpg)
3rd person cg_fov 97 cg_fovAspectAdjust 1
![fovadjustafter](https://user-images.githubusercontent.com/3673929/45390070-1df71f00-b5db-11e8-807b-964438272b9e.jpg)



Also stuffs more icons into the inventory/force/weapon selection bar, which looks cool!
Before: 
![weapicons before](https://user-images.githubusercontent.com/3673929/45390409-67943980-b5dc-11e8-996b-cfa3b3f79447.jpg)
After: 
![weapicons after](https://user-images.githubusercontent.com/3673929/45390412-6a8f2a00-b5dc-11e8-9467-c20485c2506a.jpg)