### PR TITLE
Fix GAMEVERSION on gamename update

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -590,7 +590,7 @@ void G_RegisterCvars( void ) {
 		}
 	}
 
-	trap_Cvar_Set("gamename", GAME_VERSION);
+	trap_Cvar_Set("gamename", GAMEVERSION);
 	trap_Cvar_Set("gamedate", __DATE__);
 
 	if (remapped) {


### PR DESCRIPTION
because in basejk/basemv GAME_VERSION is "basejk-1", not the mod gamename as in SaberMod