### PR TITLE
Fix cmake warning on Multithreaded params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if (NOT InMV)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4018 /wd4244 /wd4996 /wd4267 /wd4305")
 
 		# Multithreaded
-		set(CMAKE_C_FLAGS_RELEASE "/MT" CACHE TYPE INTERNAL FORCE)
+		set(CMAKE_C_FLAGS_RELEASE "/MT" CACHE INTERNAL "" FORCE)
 
 		# Platform
 		set(GlobalDefines ${GlobalDefines} "UNICODE" "_UNICODE")


### PR DESCRIPTION
Set the params properly to prevent the next warning when generating project files.
CMake Warning (dev) at CMakeLists.txt:160 (set): implicitly converting 'TYPE' to 'STRING' type.