### PR TITLE
Remove extra dot from message "hit the kill limit"

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -2108,7 +2108,7 @@ void CheckExitRules( void ) {
 			if ( cl->ps.persistant[PERS_SCORE] >= g_fraglimit.integer ) {
 				LogExit( "Kill limit hit." );
 				gDuelExit = qfalse;
-				trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " %s.\n\"",
+				trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " %s\n\"",
 												cl->pers.netname,
 												G_GetStripEdString("SVINGAME", "HIT_THE_KILL_LIMIT")
 												) 


### PR DESCRIPTION
Message from Flendo:
I have noticed in basejk and basemv that when a player hits kill limit a double dot is printed at message, one is printed from the language file and the other after printing the language file.